### PR TITLE
Performance Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clone": "^1.0.1",
     "deep-equal": "^1.0.0",
     "pako": "^0.2.5",
-    "restructure": "^0.3.2",
+    "restructure": "^0.5.0",
     "typedarray-to-buffer": "^3.0.0",
     "unicode-properties": "^1.0.0"
   },

--- a/src/CmapProcessor.coffee
+++ b/src/CmapProcessor.coffee
@@ -22,7 +22,7 @@ class CmapProcessor
     cmap = @cmap
     switch cmap.version
       when 0
-        return cmap.codeMap[codepoint] or 0
+        return cmap.codeMap.get(codepoint) or 0
         
       when 4
         min = 0
@@ -30,19 +30,19 @@ class CmapProcessor
         while min <= max
           mid = (min + max) >> 1
           
-          if codepoint < cmap.startCode[mid]
+          if codepoint < cmap.startCode.get(mid)
             max = mid - 1
-          else if codepoint > cmap.endCode[mid]
+          else if codepoint > cmap.endCode.get(mid)
             min = mid + 1
           else
-            rangeOffset = cmap.idRangeOffset[mid]
+            rangeOffset = cmap.idRangeOffset.get(mid)
             if rangeOffset is 0
-              gid = codepoint + cmap.idDelta[mid]
+              gid = codepoint + cmap.idDelta.get(mid)
             else
-              index = rangeOffset / 2 + (codepoint - cmap.startCode[mid]) - (cmap.segCount - mid)
-              gid = cmap.glyphIndexArray[index] or 0
+              index = rangeOffset / 2 + (codepoint - cmap.startCode.get(mid)) - (cmap.segCount - mid)
+              gid = cmap.glyphIndexArray.get(index) or 0
               unless gid is 0
-                gid += cmap.idDelta[mid]
+                gid += cmap.idDelta.get(mid)
                 
             return gid & 0xffff
         
@@ -52,14 +52,14 @@ class CmapProcessor
         throw new Error 'TODO: cmap format 8'
             
       when 6, 10
-        return cmap.glyphIndices[codepoint - cmap.firstCode] or 0
+        return cmap.glyphIndices.get(codepoint - cmap.firstCode) or 0
         
       when 12, 13
         min = 0
         max = cmap.nGroups - 1
         while min <= max
           mid = (min + max) >> 1
-          group = cmap.groups[mid]
+          group = cmap.groups.get(mid)
           
           if codepoint < group.startCharCode
             max = mid - 1
@@ -90,8 +90,8 @@ class CmapProcessor
           
       when 4
         res = []
-        for tail, i in cmap.endCode
-          start = cmap.startCode[i]
+        for tail, i in cmap.endCode.toArray()
+          start = cmap.startCode.get(i)
           res.push [start..tail]...
           
         @_characterSet = res
@@ -104,7 +104,7 @@ class CmapProcessor
         
       when 12, 13
         res = []
-        for group in cmap.groups
+        for group in cmap.groups.toArray()
           res.push [group.startCharCode..group.endCharCode]...
           
         @_characterSet = res

--- a/src/glyph/Glyph.coffee
+++ b/src/glyph/Glyph.coffee
@@ -27,7 +27,7 @@ class Glyph
       
     return res
     
-  _getMetrics: (cbox = @cbox) ->
+  _getMetrics: (cbox) ->
     return @_metrics if @_metrics
       
     {advance:advanceWidth, bearing:leftBearing} = getMetrics @_font.hmtx, @id
@@ -36,14 +36,17 @@ class Glyph
     if @_font.vmtx
       {advance:advanceHeight, bearing:topBearing} = getMetrics @_font.vmtx, @id
       
-    else if (os2 = @_font['OS/2']) and os2.version > 0
-      advanceHeight = Math.abs os2.typoAscender - os2.typoDescender
-      topBearing = os2.typoAscender - cbox.maxY
-    
     else
-      hhea = @_font.hhea
-      advanceHeight = Math.abs hhea.ascent - hhea.descent
-      topBearing = hhea.ascent - cbox.maxY
+      cbox ?= @cbox
+      
+      if (os2 = @_font['OS/2']) and os2.version > 0
+        advanceHeight = Math.abs os2.typoAscender - os2.typoDescender
+        topBearing = os2.typoAscender - cbox.maxY
+    
+      else
+        hhea = @_font.hhea
+        advanceHeight = Math.abs hhea.ascent - hhea.descent
+        topBearing = hhea.ascent - cbox.maxY
     
     @_metrics = { advanceWidth, advanceHeight, leftBearing, topBearing }
       

--- a/src/glyph/Glyph.coffee
+++ b/src/glyph/Glyph.coffee
@@ -19,11 +19,11 @@ class Glyph
     
   getMetrics = (table, gid) ->
     if gid < table.metrics.length
-      return table.metrics[gid]
+      return table.metrics.get gid
       
     res = 
-      advance: table.metrics[table.metrics.length - 1]?.advance or 0
-      bearing: table.bearings[gid - table.metrics.length] or 0
+      advance: table.metrics.get(table.metrics.length - 1)?.advance or 0
+      bearing: table.bearings.get(gid - table.metrics.length) or 0
       
     return res
     

--- a/src/glyph/TTFGlyph.coffee
+++ b/src/glyph/TTFGlyph.coffee
@@ -244,7 +244,9 @@ class TTFGlyph extends Glyph
     
   _getMetrics: ->
     return @_metrics if @_metrics
-    super
+    
+    cbox = @_getCBox true
+    super cbox
     
     if @_font._variationProcessor
       # Decode the font data (and cache for later).

--- a/src/opentype/GPOSProcessor.coffee
+++ b/src/opentype/GPOSProcessor.coffee
@@ -28,7 +28,7 @@ class GPOSProcessor extends OpenTypeProcessor
             @applyPositionValue 0, table.value
             
           when 2
-            @applyPositionValue 0, table.values[index]
+            @applyPositionValue 0, table.values.get(index)
             
         return true
     
@@ -41,7 +41,7 @@ class GPOSProcessor extends OpenTypeProcessor
       
         switch table.version
           when 1 # Adjustments for glyph pairs
-            set = table.pairSets[index]
+            set = table.pairSets.get(index)
             
             for pair in set when pair.secondGlyph is nextGlyph.id
               @applyPositionValue 0, pair.value1
@@ -55,7 +55,7 @@ class GPOSProcessor extends OpenTypeProcessor
             class2 = @getClassID nextGlyph.id, table.classDef2
             return false if class1 is -1 or class2 is -1
               
-            pair = table.classRecords[class1][class2]
+            pair = table.classRecords.get(class1).get(class2)
             @applyPositionValue 0, pair.value1
             @applyPositionValue 1, pair.value2
             

--- a/src/opentype/GSUBProcessor.coffee
+++ b/src/opentype/GSUBProcessor.coffee
@@ -14,14 +14,14 @@ class GSUBProcessor extends OpenTypeProcessor
             glyph.id = (glyph.id + table.deltaGlyphID) & 0xffff
             
           when 2
-            glyph.id = table.substitute[index]
+            glyph.id = table.substitute.get(index)
             
         return true
             
       when 2 # Multiple Substitution
         index = @coverageIndex table.coverage
         unless index is -1
-          sequence = table.sequence[index]
+          sequence = table.sequence.get(index)
           @glyphIterator.cur.id = sequence[0]
           @glyphs.splice @glyphIterator.index + 1, 0, (new GlyphInfo gid for gid in sequence[1..])
           return true
@@ -30,14 +30,14 @@ class GSUBProcessor extends OpenTypeProcessor
         index = @coverageIndex table.coverage
         unless index is -1
           USER_INDEX = 0 # TODO
-          @glyphIterator.cur.id = table.alternateSet[index][USER_INDEX]
+          @glyphIterator.cur.id = table.alternateSet.get(index)[USER_INDEX]
           return true
     
       when 4 # Ligature Substitution
         index = @coverageIndex table.coverage
         return false if index is -1
         
-        for ligature in table.ligatureSets[index]
+        for ligature in table.ligatureSets.get(index)
           matched = @sequenceMatchIndices 1, ligature.components
           continue unless matched
           

--- a/src/opentype/OpenTypeProcessor.coffee
+++ b/src/opentype/OpenTypeProcessor.coffee
@@ -79,7 +79,7 @@ class OpenTypeProcessor
         lookups.push 
           feature: tag
           index: lookupIndex
-          lookup: @table.lookupList[lookupIndex]
+          lookup: @table.lookupList.get(lookupIndex)
           
     lookups.sort (a, b) ->
       a.index - b.index
@@ -118,7 +118,7 @@ class OpenTypeProcessor
     for lookupRecord in lookupRecords
       @glyphIterator.index = glyphIndex + lookupRecord.sequenceIndex
       
-      lookup = @table.lookupList[lookupRecord.lookupListIndex]
+      lookup = @table.lookupList.get(lookupRecord.lookupListIndex)
       for table in lookup.subTables
         @applyLookup lookup.lookupType, table
     

--- a/src/subset/TTFSubset.coffee
+++ b/src/subset/TTFSubset.coffee
@@ -27,11 +27,11 @@ class TTFSubset extends Subset
     @loca.offsets.push @offset
     
     if gid < @font.hmtx.metrics.length
-      @hmtx.metrics.push @font.hmtx.metrics[gid]
+      @hmtx.metrics.push @font.hmtx.metrics.get gid
     else
       @hmtx.metrics.push
-        width: @font.hmtx.metrics[@font.hmtx.metrics.length - 1].advanceWidth
-        bearing: @font.hmtx.bearings[gid - @font.hmtx.metrics.length]
+        width: @font.hmtx.metrics.get(@font.hmtx.metrics.length - 1).advance
+        bearing: @font.hmtx.bearings.get(gid - @font.hmtx.metrics.length)
       
     @offset += buffer.length
     return @glyf.length - 1

--- a/src/tables/COLR.coffee
+++ b/src/tables/COLR.coffee
@@ -19,5 +19,5 @@ module.exports = new r.Struct
   version: r.uint16
   numBaseGlyphRecords: r.uint16
   baseGlyphRecord: new r.Pointer(r.uint32, new r.Array(BaseGlyphRecord, 'numBaseGlyphRecords'))
-  layerRecords: new r.Pointer(r.uint32, new r.Array(LayerRecord, 'numLayerRecords'))
+  layerRecords: new r.Pointer(r.uint32, new r.Array(LayerRecord, 'numLayerRecords'), lazy: yes)
   numLayerRecords: r.uint16

--- a/src/tables/GSUB.coffee
+++ b/src/tables/GSUB.coffee
@@ -18,25 +18,25 @@ GSUBLookup = new r.VersionedStruct 'lookupType',
     2:
       coverage:       new r.Pointer(r.uint16, Coverage)
       glyphCount:     r.uint16
-      substitute:     new r.Array(r.uint16, 'glyphCount')
+      substitute:     new r.LazyArray(r.uint16, 'glyphCount')
         
   2: # Multiple Substitution
     substFormat:    r.uint16
     coverage:       new r.Pointer(r.uint16, Coverage)
     count:          r.uint16
-    sequences:      new r.Array(new r.Pointer(r.uint16, Sequence), 'count')
+    sequences:      new r.LazyArray(new r.Pointer(r.uint16, Sequence), 'count')
     
   3: # Alternate Substitution
     substFormat:    r.uint16
     coverage:       new r.Pointer(r.uint16, Coverage)
     count:          r.uint16
-    alternateSet:   new r.Array(new r.Pointer(r.uint16, AlternateSet), 'count')
+    alternateSet:   new r.LazyArray(new r.Pointer(r.uint16, AlternateSet), 'count')
     
   4: # Ligature Substitution
     substFormat:    r.uint16
     coverage:       new r.Pointer(r.uint16, Coverage)
     count:          r.uint16
-    ligatureSets:   new r.Array(new r.Pointer(r.uint16, LigatureSet), 'count')
+    ligatureSets:   new r.LazyArray(new r.Pointer(r.uint16, LigatureSet), 'count')
     
   5: Context         # Contextual Substitution
   6: ChainingContext # Chaining Contextual Substitution

--- a/src/tables/cmap.coffee
+++ b/src/tables/cmap.coffee
@@ -31,15 +31,15 @@ CmapSubtable = new r.VersionedStruct r.uint16,
   0: # Byte encoding
     length:     r.uint16   # Total table length in bytes (set to 262 for format 0)
     language:   r.uint16   # Language code for this encoding subtable, or zero if language-independent
-    codeMap:    new r.Array(r.uint8, 256)
+    codeMap:    new r.LazyArray(r.uint8, 256)
     
   2: # High-byte mapping (CJK)
     length:           r.uint16
     language:         r.uint16
     subHeaderKeys:    new r.Array(r.uint16, 256)
-    subHeaderCount:   -> Math.max.apply(Math, @subHeaderKeys)       
-    subHeaders:       new r.Array(SubHeader, 'subHeaderCount')
-    glyphIndexArray:  new r.Array(r.uint16, 'subHeaderCount')
+    subHeaderCount:   -> Math.max.apply(Math, @subHeaderKeys)
+    subHeaders:       new r.LazyArray(SubHeader, 'subHeaderCount')
+    glyphIndexArray:  new r.LazyArray(r.uint16, 'subHeaderCount')
   
   4: # Segment mapping to delta values
     length:           r.uint16              # Total table length in bytes
@@ -49,27 +49,27 @@ CmapSubtable = new r.VersionedStruct r.uint16,
     searchRange:      r.uint16
     entrySelector:    r.uint16
     rangeShift:       r.uint16
-    endCode:          new r.Array(r.uint16, 'segCount')
+    endCode:          new r.LazyArray(r.uint16, 'segCount')
     reservedPad:      new r.Reserved(r.uint16)       # This value should be zero
-    startCode:        new r.Array(r.uint16, 'segCount')
-    idDelta:          new r.Array(r.int16, 'segCount')
-    idRangeOffset:    new r.Array(r.uint16, 'segCount')
-    glyphIndexArray:  new r.Array(r.uint16, -> (@length - @_currentOffset) / 2)
+    startCode:        new r.LazyArray(r.uint16, 'segCount')
+    idDelta:          new r.LazyArray(r.int16, 'segCount')
+    idRangeOffset:    new r.LazyArray(r.uint16, 'segCount')
+    glyphIndexArray:  new r.LazyArray(r.uint16, -> (@length - @_currentOffset) / 2)
     
   6: # Trimmed table
     length:         r.uint16
     language:       r.uint16
     firstCode:      r.uint16
     entryCount:     r.uint16
-    glyphIndices:   new r.Array(r.uint16, 'entryCount')
+    glyphIndices:   new r.LazyArray(r.uint16, 'entryCount')
     
   8: # mixed 16-bit and 32-bit coverage
     reserved: new r.Reserved(r.uint16)
     length:   r.uint32
     language: r.uint16
-    is32:     new r.Array(r.uint8, 8192)
+    is32:     new r.LazyArray(r.uint8, 8192)
     nGroups:  r.uint32
-    groups:   new r.Array(CmapGroup, 'nGroups')
+    groups:   new r.LazyArray(CmapGroup, 'nGroups')
     
   10: # Trimmed Array
     reserved:       new r.Reserved(r.uint16)
@@ -77,31 +77,31 @@ CmapSubtable = new r.VersionedStruct r.uint16,
     language:       r.uint32
     firstCode:      r.uint32
     entryCount:     r.uint32
-    glyphIndices:   new r.Array(r.uint16, 'numChars')
+    glyphIndices:   new r.LazyArray(r.uint16, 'numChars')
     
   12: # Segmented coverage
     reserved: new r.Reserved(r.uint16)
     length:   r.uint32
     language: r.uint32
     nGroups:  r.uint32
-    groups:   new r.Array(CmapGroup, 'nGroups')
+    groups:   new r.LazyArray(CmapGroup, 'nGroups')
     
   13: # Many-to-one range mappings (same as 12 except for group.startGlyphID)
     reserved: new r.Reserved(r.uint16)
     length:   r.uint32
     language: r.uint32
     nGroups:  r.uint32
-    groups:   new r.Array(CmapGroup, 'nGroups')
+    groups:   new r.LazyArray(CmapGroup, 'nGroups')
     
   14: # Unicode Variation Sequences
     length:       r.uint32
     numRecords:   r.uint32
-    varSelectors: new r.Array(VarSelectorRecord, 'numRecords')
+    varSelectors: new r.LazyArray(VarSelectorRecord, 'numRecords')
 
 CmapEntry = new r.Struct
   platformID:  r.uint16  # Platform identifier
   encodingID:  r.uint16  # Platform-specific encoding identifier
-  table:       new r.Pointer(r.uint32, CmapSubtable, type: 'parent')
+  table:       new r.Pointer(r.uint32, CmapSubtable, type: 'parent', lazy: yes)
   
 # character to glyph mapping
 module.exports = new r.Struct

--- a/src/tables/hmtx.coffee
+++ b/src/tables/hmtx.coffee
@@ -5,5 +5,5 @@ HmtxEntry = new r.Struct
   bearing: r.int16
 
 module.exports = new r.Struct
-  metrics:    new r.Array(HmtxEntry, -> @parent.hhea.numberOfMetrics)
-  bearings:   new r.Array(r.int16, -> @parent.maxp.numGlyphs - @parent.hhea.numberOfMetrics)
+  metrics:    new r.LazyArray(HmtxEntry, -> @parent.hhea.numberOfMetrics)
+  bearings:   new r.LazyArray(r.int16, -> @parent.maxp.numGlyphs - @parent.hhea.numberOfMetrics)

--- a/src/tables/opentype.coffee
+++ b/src/tables/opentype.coffee
@@ -53,7 +53,7 @@ exports.LookupList = (SubTable) ->
     subTables:          new r.Array(new r.Pointer(r.uint16, SubTable), 'subTableCount')
     markFilteringSet:   r.uint16 # TODO: only present when flags says so...
       
-  return new r.Array new r.Pointer(r.uint16, Lookup), r.uint16
+  return new r.LazyArray new r.Pointer(r.uint16, Lookup), r.uint16
   
 ##################
 # Coverage Table #

--- a/src/tables/vmtx.coffee
+++ b/src/tables/vmtx.coffee
@@ -6,5 +6,5 @@ VmtxEntry = new r.Struct
 
 # Vertical Metrics Table
 module.exports = new r.Struct
-  metrics:  new r.Array(VmtxEntry, -> @parent.vhea.numberOfMetrics)
-  bearings: new r.Array(r.int16, -> @parent.maxp.numGlyphs - @parent.vhea.numberOfMetrics)
+  metrics:  new r.LazyArray(VmtxEntry, -> @parent.vhea.numberOfMetrics)
+  bearings: new r.LazyArray(r.int16, -> @parent.maxp.numGlyphs - @parent.vhea.numberOfMetrics)


### PR DESCRIPTION
I added a `LazyArray` type, and a `lazy` pointer option to [restructure](https://github.com/devongovett/restructure), the library that fontkit uses to declaratively specify the sfnt tables. This allows data to be decoded only when needed rather than decoding the entire table up front, which improves performance dramatically for large fonts. Currently, I make use of it for the `cmap`, `hmtx`, `vmtx`, `GSUB`, and `GPOS` tables, which are usually the largest (besides the glyph paths themselves, which are already optimized). I see the biggest improvement for the `cmap` table, where there are often lots of subtables that we don't use, which we now also don't decode.