### PR TITLE
Make a plugin system for font formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 playground/
 .DS_Store
+coverage/
 coverage.html

--- a/base.coffee
+++ b/base.coffee
@@ -1,0 +1,44 @@
+r = require 'restructure'
+fs = require 'fs'
+TTFFont = require './src/TTFFont'
+WOFFFont = require './src/WOFFFont'
+WOFF2Font = require './src/WOFF2Font'
+TrueTypeCollection = require './src/TrueTypeCollection'
+DFont = require './src/DFont'
+
+formats = []
+exports.registerFormat = (format) ->
+  formats.push format
+  exports[format.name] = format
+
+exports.openSync = (filename, postscriptName) ->
+  buffer = fs.readFileSync filename
+  return exports.create buffer, postscriptName
+  
+exports.open = (filename, postscriptName, callback) ->
+  if typeof postscriptName is 'function'
+    callback = postscriptName
+    postscriptName = null
+    
+  fs.readFile filename, (err, buffer) ->
+    return callback err if err
+    
+    try
+      font = exports.create buffer, postscriptName
+    catch e
+      return callback e
+      
+    callback null, font
+    
+  return
+  
+exports.create = (buffer, postscriptName) ->
+  for format in formats
+    if format.probe buffer
+      font = new format(new r.DecodeStream(buffer))
+      if postscriptName
+        return font.getFont postscriptName
+        
+      return font
+      
+  throw new Error 'Unknown font format'

--- a/coverage.js
+++ b/coverage.js
@@ -1,5 +1,0 @@
-require('coffee-coverage').register({
-  basePath: __dirname,
-  path: 'relative',
-  exclude: ['/test', '/node_modules', '/.git'],
-});

--- a/index.coffee
+++ b/index.coffee
@@ -1,66 +1,10 @@
-r = require 'restructure'
-fs = require 'fs'
-TTFFont = require './src/TTFFont'
-WOFFFont = require './src/WOFFFont'
-WOFF2Font = require './src/WOFF2Font'
-TrueTypeCollection = require './src/TrueTypeCollection'
-DFont = require './src/DFont'
+fontkit = require './base'
 
-exports.TTFFont = TTFFont
-exports.WOFFFont = WOFFFont
-exports.WOFF2Font = WOFF2Font
-exports.TrueTypeCollection = TrueTypeCollection
-exports.DFont = DFont
+# Register font formats
+fontkit.registerFormat require './src/TTFFont'
+fontkit.registerFormat require './src/WOFFFont'
+fontkit.registerFormat require './src/WOFF2Font'
+fontkit.registerFormat require './src/TrueTypeCollection'
+fontkit.registerFormat require './src/DFont'
 
-exports.openSync = (filename, postscriptName) ->
-  buffer = fs.readFileSync filename
-  return exports.create buffer, postscriptName
-  
-exports.open = (filename, postscriptName, callback) ->
-  if typeof postscriptName is 'function'
-    callback = postscriptName
-    postscriptName = null
-    
-  fs.readFile filename, (err, buffer) ->
-    return callback err if err
-    
-    try
-      font = exports.create buffer, postscriptName
-    catch e
-      return callback e
-      
-    callback null, font
-    
-  return
-  
-exports.create = (buffer, postscriptName) ->
-  stream = new r.DecodeStream(buffer)
-  sig = stream.readString(4)
-  stream.pos = 0
-
-  switch sig
-    when 'ttcf'
-      ttc = new TrueTypeCollection(stream)
-      if postscriptName
-        return ttc.getFont(postscriptName)
-        
-      return ttc
-      
-    when 'wOFF'
-      return new WOFFFont(stream)
-      
-    when 'wOF2'
-      return new WOFF2Font(stream)
-      
-    when 'true', 'OTTO', String.fromCharCode(0, 1, 0, 0)
-      return new TTFFont(stream)
-      
-    else
-      if DFont.isDFont stream
-        dfont = new DFont(stream)
-        if postscriptName
-          return dfont.getFont(postscriptName)
-          
-        return dfont
-        
-      throw new Error 'Unknown font format'
+module.exports = fontkit

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "scripts": {
     "test": "mocha",
     "coverage": "mocha --require coverage.js --reporter html-cov > coverage.html",
-    "prepublish": "coffee -c src/ index.coffee",
-    "postpublish": "rm -rf index.js src/*.js src/**/*.js"
+    "prepublish": "coffee -c src/ *.coffee",
+    "postpublish": "rm *.js && find src -name '*.js' -delete"
   },
   "author": "Devon Govett <devongovett@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "test": "mocha",
-    "coverage": "mocha --require coverage.js --reporter html-cov > coverage.html",
+    "coverage": "mocha --require coffee-coverage/register-istanbul && istanbul report",
     "prepublish": "coffee -c src/ *.coffee",
     "postpublish": "rm *.js && find src -name '*.js' -delete"
   },
@@ -33,6 +33,7 @@
     "coffee-script": "^1.8.0",
     "concat-stream": "^1.4.6",
     "iconv-lite": "^0.4.7",
+    "istanbul": "^0.3.17",
     "mocha": "^2.0.1"
   }
 }

--- a/src/DFont.coffee
+++ b/src/DFont.coffee
@@ -36,15 +36,13 @@ class DFont
     dataLength: r.uint32
     mapLength: r.uint32
     
-  @isDFont: (stream) ->
-    pos = stream.pos
+  @probe: (buffer) ->
+    stream = new r.DecodeStream(buffer)
     
     try
       header = DFontHeader.decode stream
     catch e
       return false
-    finally
-      stream.pos = pos
       
     for type in header.map.typeList.types
       if type.name is 'sfnt'

--- a/src/TTFFont.coffee
+++ b/src/TTFFont.coffee
@@ -14,6 +14,10 @@ BBox = require './glyph/BBox'
 
 class TTFFont
   get = require('./get')(this)
+  
+  @probe: (buffer) ->
+    return buffer.toString('ascii', 0, 4) in ['true', 'OTTO', String.fromCharCode(0, 1, 0, 0)]
+  
   constructor: (@stream, variationCoords = null) ->    
     @_tables = {}
     @_glyphs = {}
@@ -177,7 +181,7 @@ class TTFFont
   # Returns an object describing the available variation axes
   # that this font supports. Keys are setting tags, and values
   # contain the axis name, range, and default value.
-  get 'variationAxes', ->    
+  get 'variationAxes', ->
     res = {}
     return res unless @fvar
     
@@ -193,7 +197,7 @@ class TTFFont
   # Returns an object describing the named variation instances
   # that the font designer has specified. Keys are variation names
   # and values are the variation settings for this instance.
-  get 'namedVariations', ->    
+  get 'namedVariations', ->
     res = {}
     return res unless @fvar
     
@@ -233,5 +237,9 @@ class TTFFont
     font._tables = @_tables
     
     return font
-        
+    
+  # Standardized format plugin API
+  getFont: (name) ->
+    return @getVariation name
+    
 module.exports = TTFFont

--- a/src/TrueTypeCollection.coffee
+++ b/src/TrueTypeCollection.coffee
@@ -16,6 +16,9 @@ class TrueTypeCollection
       dsigLength: r.uint32
       dsigOffset: r.uint32
       
+  @probe: (buffer) ->
+    return buffer.toString('ascii', 0, 4) is 'ttcf'
+      
   constructor: (@stream) ->
     if @stream.readString(4) isnt 'ttcf'
       throw new Error 'Not a TrueType collection'

--- a/src/WOFF2Font.coffee
+++ b/src/WOFF2Font.coffee
@@ -6,7 +6,10 @@ WOFF2Glyph = require './glyph/WOFF2Glyph'
 
 # Subclass of TTFFont that represents a TTF/OTF font compressed by WOFF2
 # See spec here: http://www.w3.org/TR/WOFF2/
-class WOFF2Font extends TTFFont  
+class WOFF2Font extends TTFFont
+  @probe: (buffer) ->
+    return buffer.toString('ascii', 0, 4) is 'wOF2'
+    
   WOFF2Header = new r.Struct
     tag: new r.String(4) # should be 'wOF2'
     flavor: r.uint32

--- a/src/WOFFFont.coffee
+++ b/src/WOFFFont.coffee
@@ -6,6 +6,9 @@ toBuffer = require 'typedarray-to-buffer'
 r = require 'restructure'
 
 class WOFFFont extends TTFFont
+  @probe: (buffer) ->
+    return buffer.toString('ascii', 0, 4) is 'wOFF'
+    
   _decodeDirectory: ->
     @directory = WOFFDirectory.decode(@stream, _startOffset: 0)
     


### PR DESCRIPTION
Each supported font format is now a plugin to fontkit. Each format has a static probe method that returns whether or not the given buffer is in the format. This allows users to make custom builds supporting only the formats they need (good for browsers, etc.).

```javascript
// Get the default build with all supported formats loaded
var fontkit = require('fontkit');

// Get a build with no formats loaded
var fontkit = require('fontkit/base');

// Register a format
fontkit.registerFormat(require('fontkit/src/TTFFont'));
```