### PR TITLE
A typo (using uppercase instead of lowercase in the require statement…

### DIFF
--- a/src/subset/TTFSubset.coffee
+++ b/src/subset/TTFSubset.coffee
@@ -1,6 +1,6 @@
 cloneDeep = require 'clone'
 Subset = require './Subset'
-Directory = require '../tables/Directory'
+Directory = require '../tables/directory'
 Tables = require '../tables'
 
 class TTFSubset extends Subset


### PR DESCRIPTION
…) breaks the code and also the automated tests.