### PR TITLE
Refactor OpenType shapers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
   - stable
-  - "4.x"
+  - "4"
   - "0.12"
   - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - stable
+  - "4.x"
+  - "0.12"
+  - "0.10"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "iconv-lite": "^0.4.11",
     "pako": "^0.2.5",
     "restructure": "^0.5.0",
-    "typedarray-to-buffer": "^3.0.0",
+    "typedarray-to-buffer": "~3.0.0",
     "unicode-properties": "^1.0.0",
     "unicode-trie": "^0.3.0"
   },

--- a/src/aat/AATLayoutEngine.coffee
+++ b/src/aat/AATLayoutEngine.coffee
@@ -1,0 +1,22 @@
+AATFeatureMap = require './AATFeatureMap'
+AATMorxProcessor = require './AATMorxProcessor'
+Script = require '../layout/Script'
+
+class AATLayoutEngine
+  constructor: (@font) ->
+    @morxProcessor = new AATMorxProcessor(@font)
+    
+  substitute: (glyphs, features, script, language) ->
+    # AAT expects the glyphs to be in visual order prior to morx processing,
+    # so reverse the glyphs if the script is right-to-left.
+    isRTL = Script.direction(script) is 'rtl'
+    if isRTL
+      glyphs.reverse()
+    
+    @morxProcessor.process(glyphs, AATFeatureMap.mapOTToAAT(features))
+    return glyphs
+    
+  getAvailableFeatures: (script, language) ->
+    return AATFeatureMap.mapAATToOT @morxProcessor.getSupportedFeatures()
+
+module.exports = AATLayoutEngine

--- a/src/layout/LayoutEngine.coffee
+++ b/src/layout/LayoutEngine.coffee
@@ -1,17 +1,20 @@
-GSUBProcessor = require '../opentype/GSUBProcessor'
-GPOSProcessor = require '../opentype/GPOSProcessor'
-GlyphInfo = require '../opentype/GlyphInfo'
-Shapers = require '../opentype/shapers'
-AATFeatureMap = require '../aat/AATFeatureMap'
-AATMorxProcessor = require '../aat/AATMorxProcessor'
 KernProcessor = require './KernProcessor'
 UnicodeLayoutEngine = require './UnicodeLayoutEngine'
 GlyphRun = require './GlyphRun'
 Script = require './Script'
 unicode = require 'unicode-properties'
+AATLayoutEngine = require '../aat/AATLayoutEngine'
+OTLayoutEngine = require '../opentype/OTLayoutEngine'
 
 class LayoutEngine
   constructor: (@font) ->
+    # Choose an advanced layout engine. We try the AAT morx table first since more 
+    # scripts are currently supported because the shaping logic is built into the font.
+    @engine = if @font.morx
+      new AATLayoutEngine @font
+      
+    else if @font.GSUB or @font.GPOS
+      new OTLayoutEngine @font
         
   layout: (string, features = [], script, language) ->
     # Make the userFeatures parameter optional
@@ -38,57 +41,24 @@ class LayoutEngine
             
     # Return early if there are no glyphs
     if glyphs.length is 0
-      return new GlyphRun glyphs, []    
-      
-    if not @font.morx and (@font.GSUB or @font.GPOS)
-      shaper = Shapers.choose script
-      features.push shaper.getGlobalFeatures(script)...
-      
-      # Map glyphs to GlyphInfo objects so data can be passed between
-      # GSUB and GPOS without mutating the real (shared) Glyph objects.
-      glyphs = for glyph, i in glyphs
-        new GlyphInfo glyph.id, [glyph.codePoints...], features
-        
-      features.push shaper.assignFeatures(glyphs, script, @font)...
-      
-    # Remove duplicate features
-    featureMap = {}
-    for feature in features
-      featureMap[feature] = true
-      
-    features = Object.keys(featureMap)
+      return new GlyphRun glyphs, []
+    
+    # Setup the advanced layout engine
+    @engine?.setup?(glyphs, features, script, language)
       
     # Substitute and position the glyphs
-    glyphs = @substitute glyphs, features, script
-    positions = @position glyphs, features, script
+    glyphs = @substitute glyphs, features, script, language
+    positions = @position glyphs, features, script, language
+    
+    # Let the layout engine clean up any state it might have
+    @engine?.cleanup?()
     
     return new GlyphRun glyphs, positions
     
   substitute: (glyphs, features, script, language) ->
-    # First, try AAT morx table.
-    # We do this first since more scripts are currently supported by AAT
-    # because the shaping logic is built into the font.
-    if @font.morx
-      # AAT expects the glyphs to be reversed prior to morx processing,
-      # so reverse the glyphs if the script is right-to-left.
-      isRTL = Script.direction(script) is 'rtl'
-      if isRTL
-        glyphs.reverse()
-      
-      @morxProcessor ?= new AATMorxProcessor(@font)
-      @morxProcessor.process(glyphs, AATFeatureMap.mapOTToAAT(features))
-      
-      # It is very unlikely, but possible for a font to have an AAT morx table
-      # along with an OpenType GPOS table. If so, reverse the glyphs again for
-      # GPOS, which expects glyphs to be in logical order.
-      if isRTL and @font.GPOS
-        glyphs.reverse()
-        
-    # If not found, try the OpenType GSUB table.
-    else if @font.GSUB
-      @GSUBProcessor ?= new GSUBProcessor(@font, @font.GSUB)
-      @GSUBProcessor.selectScript script, language
-      @GSUBProcessor.applyFeatures(features, glyphs)
+    # Call the advanced layout engine to make substitutions
+    if @engine?.substitute
+      glyphs = @engine.substitute(glyphs, features, script, language)
       
     return glyphs
     
@@ -96,41 +66,21 @@ class LayoutEngine
     constructor: (@xAdvance = 0, @yAdvance = 0, @xOffset = 0, @yOffset = 0) ->
       
   position: (glyphs, features, script, language) ->
-    realGlyphs = if @font.GPOS or @font.GSUB
-      # Map the GlyphInfo objects back to real Glyph objects
-      for glyph, i in glyphs
-        @font.getGlyph glyph.id, glyph.codePoints
-    else
-      glyphs
-    
+    # Get initial glyph positions
     positions = []
     for glyph, i in glyphs
-      positions.push new GlyphPosition realGlyphs[i].advanceWidth
+      positions.push new GlyphPosition glyph.advanceWidth
       
-    if @font.GPOS
-      @GPOSProcessor ?= new GPOSProcessor(@font, @font.GPOS)
-      @GPOSProcessor.selectScript script, language
-      @GPOSProcessor.applyFeatures(features, glyphs, positions)
-      
-    if @font.GPOS or @font.GSUB
-      # Restore the real Glyph objects
-      for realGlyph, i in realGlyphs
-        glyphs[i] = realGlyph
-        
-      # Reverse the glyphs and positions if the script is right-to-left
-      if Script.direction(script) is 'rtl'
-        glyphs.reverse()
-        positions.reverse()
-      
-    gposFeatures = @GPOSProcessor?.features or {}
+    # Call the advanced layout engine. Returns the features applied.
+    positioned = @engine?.position?(glyphs, positions, features, script, language)
         
     # if there is no GPOS table, use unicode properties to position marks.
-    unless @font.GPOS
+    unless positioned
       @unicodeLayoutEngine ?= new UnicodeLayoutEngine @font
       @unicodeLayoutEngine.positionGlyphs glyphs, positions
       
     # if kerning is not supported by GPOS, do kerning with the TrueType/AAT kern table
-    if 'kern' not of gposFeatures and @font.kern
+    if not positioned?.kern and @font.kern
       @kernProcessor ?= new KernProcessor @font
       @kernProcessor.process glyphs, positions
           
@@ -138,23 +88,11 @@ class LayoutEngine
     
   getAvailableFeatures: (script, language) ->
     features = []
-  
-    if @font.GSUB
-      @GSUBProcessor ?= new GSUBProcessor @font, @font.GSUB
-      @GSUBProcessor.selectScript script, language
-      features.push Object.keys(@GSUBProcessor.features)...
-  
-    if @font.GPOS
-      @GPOSProcessor ?= new GPOSProcessor @font, @font.GPOS
-      @GPOSProcessor.selectScript script, language
-      features.push Object.keys(@GPOSProcessor.features)...
     
-    if @font.morx
-      @morxProcessor ?= new AATMorxProcessor @font
-      aatFeatures = AATFeatureMap.mapAATToOT @morxProcessor.getSupportedFeatures()
-      features.push aatFeatures...
+    if @engine
+      features.push @engine.getAvailableFeatures(script, language)...
     
-    if @font.kern and (not @font.GPOS or 'kern' not of @GPOSProcessor.features)
+    if @font.kern and 'kern' not in features
       features.push 'kern'
     
     return features

--- a/src/opentype/GPOSProcessor.coffee
+++ b/src/opentype/GPOSProcessor.coffee
@@ -1,6 +1,6 @@
-OpenTypeProcessor = require './OpenTypeProcessor'
+OTProcessor = require './OTProcessor'
 
-class GPOSProcessor extends OpenTypeProcessor
+class GPOSProcessor extends OTProcessor
   applyPositionValue: (sequenceIndex, value) ->
     position = @positions[@glyphIterator.peekIndex sequenceIndex]
     if value.xAdvance?

--- a/src/opentype/GSUBProcessor.coffee
+++ b/src/opentype/GSUBProcessor.coffee
@@ -1,7 +1,7 @@
-OpenTypeProcessor = require './OpenTypeProcessor'
+OTProcessor = require './OTProcessor'
 GlyphInfo = require './GlyphInfo'
 
-class GSUBProcessor extends OpenTypeProcessor
+class GSUBProcessor extends OTProcessor
   applyLookup: (lookupType, table) ->
     switch lookupType
       when 1 # Single Substitution

--- a/src/opentype/OTLayoutEngine.coffee
+++ b/src/opentype/OTLayoutEngine.coffee
@@ -1,0 +1,68 @@
+ShapingPlan = require './ShapingPlan'
+Shapers = require './shapers'
+GlyphInfo = require './GlyphInfo'
+GSUBProcessor = require './GSUBProcessor'
+GPOSProcessor = require './GPOSProcessor'
+
+class OTLayoutEngine
+  constructor: (@font) ->
+    if @font.GSUB
+      @GSUBProcessor = new GSUBProcessor(@font, @font.GSUB)
+      
+    if @font.GPOS
+      @GPOSProcessor = new GPOSProcessor(@font, @font.GPOS)
+      
+    @glyphInfos = null
+    @plan = null
+    
+  setup: (glyphs, features, script, language) ->    
+    # Map glyphs to GlyphInfo objects so data can be passed between
+    # GSUB and GPOS without mutating the real (shared) Glyph objects.
+    @glyphInfos = for glyph, i in glyphs
+      new GlyphInfo glyph.id, [glyph.codePoints...]
+      
+    # Choose a shaper based on the script, and setup a shaping plan.
+    # This determines which features to apply to which glyphs.
+    shaper = Shapers.choose script
+    @plan = new ShapingPlan @font, script, language
+    shaper.plan(@plan, @glyphInfos, features)
+    
+  substitute: (glyphs) ->
+    if @GSUBProcessor
+      @plan.process @GSUBProcessor, @glyphInfos
+      
+      # Map glyph infos back to normal Glyph objects
+      glyphs = for glyphInfo in @glyphInfos
+        @font.getGlyph glyphInfo.id, glyphInfo.codePoints
+        
+    return glyphs
+    
+  position: (glyphs, positions) ->
+    if @GPOSProcessor
+      @plan.process @GPOSProcessor, @glyphInfos, positions
+            
+    # Reverse the glyphs and positions if the script is right-to-left
+    if @plan.direction is 'rtl'
+      glyphs.reverse()
+      positions.reverse()
+    
+    return @GPOSProcessor?.features
+    
+  cleanup: ->
+    @glyphInfos = null
+    @plan = null
+    
+  getAvailableFeatures: (script, language) ->
+    features = []
+  
+    if @GSUBProcessor
+      @GSUBProcessor.selectScript script, language
+      features.push Object.keys(@GSUBProcessor.features)...
+  
+    if @GPOSProcessor
+      @GPOSProcessor.selectScript script, language
+      features.push Object.keys(@GPOSProcessor.features)...
+      
+    return features
+
+module.exports = OTLayoutEngine

--- a/src/opentype/OTProcessor.coffee
+++ b/src/opentype/OTProcessor.coffee
@@ -1,7 +1,7 @@
 GlyphIterator = require './GlyphIterator'
 Script = require '../layout/Script'
 
-class OpenTypeProcessor
+class OTProcessor
   constructor: (@font, @table) ->
     @script = null
     @scriptTag = null
@@ -242,4 +242,4 @@ class OpenTypeProcessor
            @coverageSequenceMatches(table.inputGlyphCount, table.lookaheadCoverage)
              return @applyLookupList table.lookupRecords
     
-module.exports = OpenTypeProcessor
+module.exports = OTProcessor

--- a/src/opentype/ShapingPlan.coffee
+++ b/src/opentype/ShapingPlan.coffee
@@ -1,0 +1,84 @@
+Script = require '../layout/Script'
+
+# ShapingPlans are used by the OpenType shapers to store which
+# features should by applied, and in what order to apply them.
+# The features are applied in groups called stages. A feature
+# can be applied globally to all glyphs, or locally to only
+# specific glyphs.
+class ShapingPlan
+  constructor: (@font, @script, @language) ->
+    @direction = Script.direction(@script)
+    @stages = []
+    @globalFeatures = {}
+    @allFeatures = {}
+    
+  # Adds the given features to the last stage.
+  # Ignores features that have already been applied.
+  _addFeatures: (features) ->
+    stage = @stages[@stages.length - 1]
+    for feature in features
+      unless @allFeatures[feature]
+        stage.push feature
+        @allFeatures[feature] = true
+      
+    return
+    
+  # Adds the given features to the global list
+  _addGlobal: (features) ->
+    for feature in features
+      @globalFeatures[feature] = true
+      
+    return
+    
+  # Add features to the last stage
+  add: (arg, global = true) ->
+    if @stages.length is 0
+      @stages.push []
+    
+    if typeof arg is 'string'
+      arg = [arg]
+    
+    if Array.isArray(arg)
+      @_addFeatures arg
+      if global
+        @_addGlobal arg
+        
+    else if typeof arg is 'object'
+      features = (arg.global || []).concat(arg.local || [])
+      @_addFeatures features
+      if arg.global
+        @_addGlobal arg.global
+        
+    else
+      throw new Error "Unsupported argument to ShapingPlan#add"
+  
+  # Add a new stage
+  addStage: (arg, global) ->
+    if typeof arg is 'function'
+      @stages.push arg, []
+    else
+      @stages.push []
+      @add arg, global
+      
+  # Assigns the global features to the given glyphs
+  assignGlobalFeatures: (glyphs) ->
+    for glyph in glyphs
+      for feature of @globalFeatures
+        glyph.features[feature] = true
+        
+    return
+    
+  # Executes the planned stages using the given OTProcessor
+  process: (processor, glyphs, positions) ->
+    processor.selectScript @script, @language
+    
+    for item in @stages
+      if typeof item is 'function'
+        item(glyphs, positions)
+        
+      else if item.length > 0
+        processor.applyFeatures(item, glyphs, positions)
+        
+    return
+  
+module.exports = ShapingPlan

--- a/src/opentype/shapers/ArabicShaper.coffee
+++ b/src/opentype/shapers/ArabicShaper.coffee
@@ -13,10 +13,13 @@ trie = new UnicodeTrie fs.readFileSync __dirname + '/data.trie'
 # https://github.com/behdad/harfbuzz/blob/master/src/hb-ot-shape-complex-arabic.cc
 #
 class ArabicShaper extends DefaultShaper
-  @getGlobalFeatures: (script, isVertical = false) ->
-    features = super
-    features.push 'mset'
-    return features
+  FEATURES = ['isol', 'fina', 'fin2', 'fin3', 'medi', 'med2', 'init']
+  @planFeatures: (plan) ->
+    plan.add ['ccmp', 'locl']
+    for feature in FEATURES
+      plan.addStage feature, false
+      
+    plan.addStage 'mset'
     
   ShapingClasses = 
     Non_Joining: 0
@@ -72,8 +75,8 @@ class ArabicShaper extends DefaultShaper
 
     return ShapingClasses.Non_Joining
     
-  @assignFeatures: (glyphs, script) ->
-    features = super
+  @assignFeatures: (plan, glyphs) ->
+    super
         
     prev = -1
     state = 0
@@ -99,7 +102,6 @@ class ArabicShaper extends DefaultShaper
       if feature = actions[index]
         glyph.features[feature] = true
 
-    features.push 'isol', 'fina', 'fin2', 'fin3', 'medi', 'med2', 'init'
-    return features
+    return
   
 module.exports = ArabicShaper

--- a/src/opentype/shapers/HangulShaper.coffee
+++ b/src/opentype/shapers/HangulShaper.coffee
@@ -93,8 +93,11 @@ class HangulShaper extends DefaultShaper
     # State 3: <L,V,T> or <LVT>
     [ [ NO_ACTION, 0 ], [ NO_ACTION, 1 ], [ NO_ACTION, 0 ], [ NO_ACTION, 0 ], [ DECOMPOSE, 2 ], [ DECOMPOSE, 3 ], [ TONE_MARK, 0 ] ]
   ]
+  
+  @planFeatures: (plan) ->
+    plan.add ['ljmo', 'vjmo', 'tjmo'], false
       
-  @assignFeatures: (glyphs, script, font) ->
+  @assignFeatures: (plan, glyphs) ->
     state = 0
     i = 0
     while i < glyphs.length
@@ -107,24 +110,24 @@ class HangulShaper extends DefaultShaper
       switch action
         when DECOMPOSE
           # Decompose the composed syllable if it is not supported by the font.
-          unless font.hasGlyphForCodePoint code
-            i = decompose glyphs, i, font
+          unless plan.font.hasGlyphForCodePoint code
+            i = decompose glyphs, i, plan.font
       
         when COMPOSE
           # Found a decomposed syllable. Try to compose if supported by the font.
-          i = compose glyphs, i, font
+          i = compose glyphs, i, plan.font
           
         when TONE_MARK
           # Got a valid syllable, followed by a tone mark. Move the tone mark to the beginning of the syllable.
-          reorderToneMark glyphs, i, font
+          reorderToneMark glyphs, i, plan.font
           
         when INVALID
           # Tone mark has no valid syllable to attach to, so insert a dotted circle
-          i = insertDottedCircle glyphs, i, font
+          i = insertDottedCircle glyphs, i, plan.font
                 
       i++
 
-    return ['ljmo', 'vjmo', 'tjmo']
+    return
     
   getGlyph = (font, code, features) ->
     return new GlyphInfo font.glyphForCodePoint(code).id, [code], Object.keys features


### PR DESCRIPTION
This separates the OpenType and AAT shaping logic, and refactors the OpenType shapers.

The OT shapers now use a ShapingPlan object to store features to apply, and in which order to apply them. Features are grouped into stages, and each stage is processed separately. This allows shapers to control the order in which features are applied, and override the order defined by the font. The arabic shaper does this, and is necessary for some fonts where the defined order is wrong.

Also added Travis CI. 😀