### PR TITLE
Use bcp-47 language codes in name table

### DIFF
--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -97,9 +97,10 @@ export default class TTFFont {
 
   /**
    * Gets a string from the font's `name` table
+   * `lang` is a BCP-47 language code.
    * @return {string}
    */
-  getName(key, lang = 'English') {
+  getName(key, lang = 'en') {
     let record = this.name.records[key];
     if (record) {
       return record[lang];
@@ -423,7 +424,7 @@ export default class TTFFont {
 
     for (let axis of this.fvar.axis) {
       res[axis.axisTag] = {
-        name: axis.name,
+        name: axis.name.en,
         min: axis.minValue,
         default: axis.defaultValue,
         max: axis.maxValue
@@ -453,7 +454,7 @@ export default class TTFFont {
         settings[axis.axisTag] = instance.coord[i];
       }
 
-      res[instance.name] = settings;
+      res[instance.name.en] = settings;
     }
 
     return res;

--- a/src/tables/feat.js
+++ b/src/tables/feat.js
@@ -3,7 +3,7 @@ import r from 'restructure';
 let Setting = new r.Struct({
   setting: r.uint16,
   nameIndex: r.int16,
-  name() { return this.parent.parent.parent.name.records.fontFeatures.English[this.nameIndex] }
+  name: t => t.parent.parent.parent.name.records.fontFeatures[t.nameIndex]
 });
 
 let FeatureName = new r.Struct({
@@ -16,7 +16,7 @@ let FeatureName = new r.Struct({
   ]),
   defaultSetting: r.uint8,
   nameIndex: r.int16,
-  name() { return this.parent.parent.name.records.fontFeatures.English[this.nameIndex] }
+  name: t => t.parent.parent.name.records.fontFeatures[t.nameIndex]
 });
 
 export default new r.Struct({

--- a/src/tables/fvar.js
+++ b/src/tables/fvar.js
@@ -1,10 +1,5 @@
 import r from 'restructure';
 
-function getName() {
-  let features = this.parent.parent.name.records.fontFeatures;
-  return features && features.English && features.English[this.nameID];
-}
-
 let Axis = new r.Struct({
   axisTag: new r.String(4),
   minValue: r.fixed32,
@@ -12,12 +7,12 @@ let Axis = new r.Struct({
   maxValue: r.fixed32,
   flags: r.uint16,
   nameID: r.uint16,
-  name: getName
+  name: t => t.parent.parent.name.records.fontFeatures[t.nameID]
 });
 
 let Instance = new r.Struct({
   nameID: r.uint16,
-  name: getName,
+  name: t => t.parent.parent.name.records.fontFeatures[t.nameID],
   flags: r.uint16,
   coord: new r.Array(r.fixed32, t => t.parent.axisCount)
 });

--- a/src/tables/name.js
+++ b/src/tables/name.js
@@ -11,12 +11,12 @@ let NameRecord = new r.Struct({
     { type: 'parent', relativeTo: 'parent.stringOffset', allowNull: false }
   )
 });
-
+  
 let LangTagRecord = new r.Struct({
   length:  r.uint16,
   tag:     new r.Pointer(r.uint16, new r.String('length', 'utf16be'), {type: 'parent', relativeTo: 'stringOffset'})
 });
-
+  
 var NameTable = new r.VersionedStruct(r.uint16, {
   0: {
     count:          r.uint16,
@@ -34,7 +34,7 @@ var NameTable = new r.VersionedStruct(r.uint16, {
 
 export default NameTable;
 
-let NAMES = [
+const NAMES = [
   'copyright',
   'fontFamily',
   'fontSubfamily',
@@ -60,10 +60,10 @@ let NAMES = [
   'wwsSubfamilyName'
 ];
 
-let ENCODINGS = [
+const ENCODINGS = [
   // unicode
   ['utf16be', 'utf16be', 'utf16be', 'utf16be', 'utf16be', 'utf16be'],
-
+  
   // macintosh
   // Mappings available at http://unicode.org/Public/MAPPINGS/VENDORS/APPLE/
   // 0	  Roman                 17	Malayalam
@@ -86,258 +86,175 @@ let ENCODINGS = [
   ['macroman', 'shift-jis', 'big5', 'euc-kr', 'iso-8859-6', 'iso-8859-8',
    'macgreek', 'maccyrillic', 'symbol', 'Devanagari', 'Gurmukhi', 'Gujarati',
    'Oriya', 'Bengali', 'Tamil', 'Telugu', 'Kannada', 'Malayalam', 'Sinhalese',
-   'Burmese', 'Khmer', 'macthai', 'Laotian', 'Georgian', 'Armenian', 'gb-2312-80',
+   'Burmese', 'Khmer', 'macthai', 'Laotian', 'Georgian', 'Armenian', 'gb-2312-80', 
    'Tibetan', 'Mongolian', 'Geez', 'maccyrillic', 'Vietnamese', 'Sindhi'],
-
+  
   // ISO (deprecated)
   ['ascii'],
-
+  
   // windows
   // Docs here: http://msdn.microsoft.com/en-us/library/system.text.encoding(v=vs.110).aspx
   ['symbol', 'utf16be', 'shift-jis', 'gb18030', 'big5', 'wansung', 'johab', null, null, null, 'ucs-4']
 ];
 
-let LANGUAGES = [
+const LANGUAGES = [
   // unicode
   [],
-
+  
   { // macintosh
-     0: "English",                          59: "Pashto",
-     1: "French",                           60: "Kurdish",
-     2: "German",                           61: "Kashmiri",
-     3: "Italian",                          62: "Sindhi",
-     4: "Dutch",                            63: "Tibetan",
-     5: "Swedish",                          64: "Nepali",
-     6: "Spanish",                          65: "Sanskrit",
-     7: "Danish",                           66: "Marathi",
-     8: "Portuguese",                       67: "Bengali",
-     9: "Norwegian",                        68: "Assamese",
-    10: "Hebrew",                           69: "Gujarati",
-    11: "Japanese",                         70: "Punjabi",
-    12: "Arabic",                           71: "Oriya",
-    13: "Finnish",                          72: "Malayalam",
-    14: "Greek",                            73: "Kannada",
-    15: "Icelandic",                        74: "Tamil",
-    16: "Maltese",                          75: "Telugu",
-    17: "Turkish",                          76: "Sinhalese",
-    18: "Croatian",                         77: "Burmese",
-    19: "Chinese (Traditional)",            78: "Khmer",
-    20: "Urdu",                             79: "Lao",
-    21: "Hindi",                            80: "Vietnamese",
-    22: "Thai",                             81: "Indonesian",
-    23: "Korean",                           82: "Tagalong",
-    24: "Lithuanian",                       83: "Malay (Roman script)",
-    25: "Polish",                           84: "Malay (Arabic script)",
-    26: "Hungarian",                        85: "Amharic",
-    27: "Estonian",                         86: "Tigrinya",
-    28: "Latvian",                          87: "Galla",
-    29: "Sami",                             88: "Somali",
-    30: "Faroese",                          89: "Swahili",
-    31: "Farsi/Persian",                    90: "Kinyarwanda/Ruanda",
-    32: "Russian",                          91: "Rundi",
-    33: "Chinese (Simplified)",             92: "Nyanja/Chewa",
-    34: "Flemish",                          93: "Malagasy",
-    35: "Irish Gaelic",                     94: "Esperanto",
-    36: "Albanian",                         128: "Welsh",
-    37: "Romanian",                         129: "Basque",
-    38: "Czech",                            130: "Catalan",
-    39: "Slovak",                           131: "Latin",
-    40: "Slovenian",                        132: "Quenchua",
-    41: "Yiddish",                          133: "Guarani",
-    42: "Serbian",                          134: "Aymara",
-    43: "Macedonian",                       135: "Tatar",
-    44: "Bulgarian",                        136: "Uighur",
-    45: "Ukrainian",                        137: "Dzongkha",
-    46: "Byelorussian",                     138: "Javanese (Roman script)",
-    47: "Uzbek",                            139: "Sundanese (Roman script)",
-    48: "Kazakh",                           140: "Galician",
-    49: "Azerbaijani (Cyrillic script)",    141: "Afrikaans",
-    50: "Azerbaijani (Arabic script)",      142: "Breton",
-    51: "Armenian",                         143: "Inuktitut",
-    52: "Georgian",                         144: "Scottish Gaelic",
-    53: "Moldavian",                        145: "Manx Gaelic",
-    54: "Kirghiz",                          146: "Irish Gaelic (with dot above)",
-    55: "Tajiki",                           147: "Tongan",
-    56: "Turkmen",                          148: "Greek (polytonic)",
-    57: "Mongolian (Mongolian script)",     149: "Greenlandic",
-    58: "Mongolian (Cyrillic script)",      150: "Azerbaijani (Roman script)"
+    0: 'en',        30: 'fo',       60: 'ks',       90: 'rw',
+    1: 'fr',        31: 'fa',       61: 'ku',       91: 'rn',
+    2: 'de',        32: 'ru',       62: 'sd',       92: 'ny',
+    3: 'it',        33: 'zh',       63: 'bo',       93: 'mg',
+    4: 'nl',        34: 'nl-BE',    64: 'ne',       94: 'eo',
+    5: 'sv',        35: 'ga',       65: 'sa',       128: 'cy',
+    6: 'es',        36: 'sq',       66: 'mr',       129: 'eu',
+    7: 'da',        37: 'ro',       67: 'bn',       130: 'ca',
+    8: 'pt',        38: 'cz',       68: 'as',       131: 'la',
+    9: 'no',        39: 'sk',       69: 'gu',       132: 'qu',
+    10: 'he',       40: 'si',       70: 'pa',       133: 'gn',
+    11: 'ja',       41: 'yi',       71: 'or',       134: 'ay',
+    12: 'ar',       42: 'sr',       72: 'ml',       135: 'tt',
+    13: 'fi',       43: 'mk',       73: 'kn',       136: 'ug',
+    14: 'el',       44: 'bg',       74: 'ta',       137: 'dz',
+    15: 'is',       45: 'uk',       75: 'te',       138: 'jv',
+    16: 'mt',       46: 'be',       76: 'si',       139: 'su',
+    17: 'tr',       47: 'uz',       77: 'my',       140: 'gl',
+    18: 'hr',       48: 'kk',       78: 'km',       141: 'af',
+    19: 'zh-Hant',  49: 'az-Cyrl',  79: 'lo',       142: 'br',
+    20: 'ur',       50: 'az-Arab',  80: 'vi',       143: 'iu',
+    21: 'hi',       51: 'hy',       81: 'id',       144: 'gd',
+    22: 'th',       52: 'ka',       82: 'tl',       145: 'gv',
+    23: 'ko',       53: 'mo',       83: 'ms',       146: 'ga',
+    24: 'lt',       54: 'ky',       84: 'ms-Arab',  147: 'to',
+    25: 'pl',       55: 'tg',       85: 'am',       148: 'el-polyton',
+    26: 'hu',       56: 'tk',       86: 'ti',       149: 'kl',
+    27: 'es',       57: 'mn-CN',    87: 'om',       150: 'az',
+    28: 'lv',       58: 'mn',       88: 'so',       151: 'nn',
+    29: 'se',       59: 'ps',       89: 'sw',
   },
-
+  
   // ISO (deprecated)
   [],
-
-  { // windows
-    0x0436: "Afrikaans",               0x0453: "Khmer",
-    0x041C: "Albanian",                0x0486: "K'iche",
-    0x0484: "Alsatian",                0x0487: "Kinyarwanda",
-    0x045E: "Amharic",                 0x0441: "Kiswahili",
-    0x1401: "Arabic",                  0x0457: "Konkani",
-    0x3C01: "Arabic",                  0x0412: "Korean",
-    0x0C01: "Arabic",                  0x0440: "Kyrgyz",
-    0x0801: "Arabic",                  0x0454: "Lao",
-    0x2C01: "Arabic",                  0x0426: "Latvian",
-    0x3401: "Arabic",                  0x0427: "Lithuanian",
-    0x3001: "Arabic",                  0x082E: "Lower Sorbian",
-    0x1001: "Arabic",                  0x046E: "Luxembourgish",
-    0x1801: "Arabic",                  0x042F: "Macedonian (FYROM)",
-    0x2001: "Arabic",                  0x083E: "Malay",
-    0x4001: "Arabic",                  0x043E: "Malay",
-    0x0401: "Arabic",                  0x044C: "Malayalam",
-    0x2801: "Arabic",                  0x043A: "Maltese",
-    0x1C01: "Arabic",                  0x0481: "Maori",
-    0x3801: "Arabic",                  0x047A: "Mapudungun",
-    0x2401: "Arabic",                  0x044E: "Marathi",
-    0x042B: "Armenian",                0x047C: "Mohawk",
-    0x044D: "Assamese",                0x0450: "Mongolian (Cyrillic)",
-    0x082C: "Azeri (Cyrillic)",        0x0850: "Mongolian (Traditional)",
-    0x042C: "Azeri (Latin)",           0x0461: "Nepali",
-    0x046D: "Bashkir",                 0x0414: "Norwegian (Bokmal)",
-    0x042D: "Basque",                  0x0814: "Norwegian (Nynorsk)",
-    0x0423: "Belarusian",              0x0482: "Occitan",
-    0x0845: "Bengali",                 0x0448: "Odia (formerly Oriya)",
-    0x0445: "Bengali",                 0x0463: "Pashto",
-    0x201A: "Bosnian (Cyrillic)",      0x0415: "Polish",
-    0x141A: "Bosnian (Latin)",         0x0416: "Portuguese",
-    0x047E: "Breton",                  0x0816: "Portuguese",
-    0x0402: "Bulgarian",               0x0446: "Punjabi",
-    0x0403: "Catalan",                 0x046B: "Quechua",
-    0x0C04: "Chinese",                 0x086B: "Quechua",
-    0x1404: "Chinese",                 0x0C6B: "Quechua",
-    0x0804: "Chinese",                 0x0418: "Romanian",
-    0x1004: "Chinese",                 0x0417: "Romansh",
-    0x0404: "Chinese",                 0x0419: "Russian",
-    0x0483: "Corsican",                0x243B: "Sami (Inari)",
-    0x041A: "Croatian",                0x103B: "Sami (Lule)",
-    0x101A: "Croatian (Latin)",        0x143B: "Sami (Lule)",
-    0x0405: "Czech",                   0x0C3B: "Sami (Northern)",
-    0x0406: "Danish",                  0x043B: "Sami (Northern)",
-    0x048C: "Dari",                    0x083B: "Sami (Northern)",
-    0x0465: "Divehi",                  0x203B: "Sami (Skolt)",
-    0x0813: "Dutch",                   0x183B: "Sami (Southern)",
-    0x0413: "Dutch",                   0x1C3B: "Sami (Southern)",
-    0x0C09: "English",                 0x044F: "Sanskrit",
-    0x2809: "English",                 0x1C1A: "Serbian (Cyrillic)",
-    0x1009: "English",                 0x0C1A: "Serbian (Cyrillic)",
-    0x2409: "English",                 0x181A: "Serbian (Latin)",
-    0x4009: "English",                 0x081A: "Serbian (Latin)",
-    0x1809: "English",                 0x046C: "Sesotho sa Leboa",
-    0x2009: "English",                 0x0432: "Setswana",
-    0x4409: "English",                 0x045B: "Sinhala",
-    0x1409: "English",                 0x041B: "Slovak",
-    0x3409: "English",                 0x0424: "Slovenian",
-    0x4809: "English",                 0x2C0A: "Spanish",
-    0x1C09: "English",                 0x400A: "Spanish",
-    0x2C09: "English",                 0x340A: "Spanish",
-    0x0809: "English",                 0x240A: "Spanish",
-    0x0409: "English",                 0x140A: "Spanish",
-    0x3009: "English",                 0x1C0A: "Spanish",
-    0x0425: "Estonian",                0x300A: "Spanish",
-    0x0438: "Faroese",                 0x440A: "Spanish",
-    0x0464: "Filipino",                0x100A: "Spanish",
-    0x040B: "Finnish",                 0x480A: "Spanish",
-    0x080C: "French",                  0x080A: "Spanish",
-    0x0C0C: "French",                  0x4C0A: "Spanish",
-    0x040C: "French",                  0x180A: "Spanish",
-    0x140c: "French",                  0x3C0A: "Spanish",
-    0x180C: "French",                  0x280A: "Spanish",
-    0x100C: "French",                  0x500A: "Spanish",
-    0x0462: "Frisian",                 0x0C0A: "Spanish (Modern Sort)",
-    0x0456: "Galician",                0x040A: "Spanish (Traditional Sort)",
-    0x0437: "Georgian",                0x540A: "Spanish",
-    0x0C07: "German",                  0x380A: "Spanish",
-    0x0407: "German",                  0x200A: "Spanish",
-    0x1407: "German",                  0x081D: "Sweden",
-    0x1007: "German",                  0x041D: "Swedish",
-    0x0807: "German",                  0x045A: "Syriac",
-    0x0408: "Greek",                   0x0428: "Tajik (Cyrillic)",
-    0x046F: "Greenlandic",             0x085F: "Tamazight (Latin)",
-    0x0447: "Gujarati",                0x0449: "Tamil",
-    0x0468: "Hausa (Latin)",           0x0444: "Tatar",
-    0x040D: "Hebrew",                  0x044A: "Telugu",
-    0x0439: "Hindi",                   0x041E: "Thai",
-    0x040E: "Hungarian",               0x0451: "Tibetan",
-    0x040F: "Icelandic",               0x041F: "Turkish",
-    0x0470: "Igbo",                    0x0442: "Turkmen",
-    0x0421: "Indonesian",              0x0480: "Uighur",
-    0x045D: "Inuktitut",               0x0422: "Ukrainian",
-    0x085D: "Inuktitut (Latin)",       0x042E: "Upper Sorbian",
-    0x083C: "Irish",                   0x0420: "Urdu",
-    0x0434: "isiXhosa",                0x0843: "Uzbek (Cyrillic)",
-    0x0435: "isiZulu",                 0x0443: "Uzbek (Latin)",
-    0x0410: "Italian",                 0x042A: "Vietnamese",
-    0x0810: "Italian",                 0x0452: "Welsh",
-    0x0411: "Japanese",                0x0488: "Wolof",
-    0x044B: "Kannada",                 0x0485: "Yakut",
-    0x043F: "Kazakh",                  0x0478: "Yi",
-    0x046A: "Yoruba"
+  
+  { // windows                                        
+    0x0436: 'af',       0x4009: 'en-IN',    0x0487: 'rw',          0x0432: 'tn',       
+    0x041C: 'sq',       0x1809: 'en-IE',    0x0441: 'sw',          0x045B: 'si',          
+    0x0484: 'gsw',      0x2009: 'en-JM',    0x0457: 'kok',         0x041B: 'sk',          
+    0x045E: 'am',       0x4409: 'en-MY',    0x0412: 'ko',          0x0424: 'sl',          
+    0x1401: 'ar-DZ',    0x1409: 'en-NZ',    0x0440: 'ky',          0x2C0A: 'es-AR',       
+    0x3C01: 'ar-BH',    0x3409: 'en-PH',    0x0454: 'lo',          0x400A: 'es-BO',       
+    0x0C01: 'ar',       0x4809: 'en-SG',    0x0426: 'lv',          0x340A: 'es-CL',       
+    0x0801: 'ar-IQ',    0x1C09: 'en-ZA',    0x0427: 'lt',          0x240A: 'es-CO',       
+    0x2C01: 'ar-JO',    0x2C09: 'en-TT',    0x082E: 'dsb',         0x140A: 'es-CR',       
+    0x3401: 'ar-KW',    0x0809: 'en-GB',    0x046E: 'lb',          0x1C0A: 'es-DO',       
+    0x3001: 'ar-LB',    0x0409: 'en',       0x042F: 'mk',          0x300A: 'es-EC',       
+    0x1001: 'ar-LY',    0x3009: 'en-ZW',    0x083E: 'ms-BN',       0x440A: 'es-SV',       
+    0x1801: 'ary',      0x0425: 'et',       0x043E: 'ms',          0x100A: 'es-GT',       
+    0x2001: 'ar-OM',    0x0438: 'fo',       0x044C: 'ml',          0x480A: 'es-HN',       
+    0x4001: 'ar-QA',    0x0464: 'fil',      0x043A: 'mt',          0x080A: 'es-MX',       
+    0x0401: 'ar-SA',    0x040B: 'fi',       0x0481: 'mi',          0x4C0A: 'es-NI',       
+    0x2801: 'ar-SY',    0x080C: 'fr-BE',    0x047A: 'arn',         0x180A: 'es-PA',       
+    0x1C01: 'aeb',      0x0C0C: 'fr-CA',    0x044E: 'mr',          0x3C0A: 'es-PY',       
+    0x3801: 'ar-AE',    0x040C: 'fr',       0x047C: 'moh',         0x280A: 'es-PE',       
+    0x2401: 'ar-YE',    0x140C: 'fr-LU',    0x0450: 'mn',          0x500A: 'es-PR',       
+    0x042B: 'hy',       0x180C: 'fr-MC',    0x0850: 'mn-CN',       0x0C0A: 'es',          
+    0x044D: 'as',       0x100C: 'fr-CH',    0x0461: 'ne',          0x040A: 'es',          
+    0x082C: 'az-Cyrl',  0x0462: 'fy',       0x0414: 'nb',          0x540A: 'es-US',       
+    0x042C: 'az',       0x0456: 'gl',       0x0814: 'nn',          0x380A: 'es-UY',     
+    0x046D: 'ba',       0x0437: 'ka',       0x0482: 'oc',          0x200A: 'es-VE',       
+    0x042D: 'eu',       0x0C07: 'de-AT',    0x0448: 'or',          0x081D: 'sv-FI',       
+    0x0423: 'be',       0x0407: 'de',       0x0463: 'ps',          0x041D: 'sv',          
+    0x0845: 'bn',       0x1407: 'de-LI',    0x0415: 'pl',          0x045A: 'syr',         
+    0x0445: 'bn-IN',    0x1007: 'de-LU',    0x0416: 'pt',          0x0428: 'tg',          
+    0x201A: 'bs-Cyrl',  0x0807: 'de-CH',    0x0816: 'pt-PT',       0x085F: 'tzm',         
+    0x141A: 'bs',       0x0408: 'el',       0x0446: 'pa',          0x0449: 'ta',          
+    0x047E: 'br',       0x046F: 'kl',       0x046B: 'qu-BO',       0x0444: 'tt',          
+    0x0402: 'bg',       0x0447: 'gu',       0x086B: 'qu-EC',       0x044A: 'te',          
+    0x0403: 'ca',       0x0468: 'ha',       0x0C6B: 'qu',          0x041E: 'th',          
+    0x0C04: 'zh-HK',    0x040D: 'he',       0x0418: 'ro',          0x0451: 'bo',          
+    0x1404: 'zh-MO',    0x0439: 'hi',       0x0417: 'rm',          0x041F: 'tr',          
+    0x0804: 'zh',       0x040E: 'hu',       0x0419: 'ru',          0x0442: 'tk',          
+    0x1004: 'zh-SG',    0x040F: 'is',       0x243B: 'smn',         0x0480: 'ug',          
+    0x0404: 'zh-TW',    0x0470: 'ig',       0x103B: 'smj-NO',      0x0422: 'uk',          
+    0x0483: 'co',       0x0421: 'id',       0x143B: 'smj',         0x042E: 'hsb',         
+    0x041A: 'hr',       0x045D: 'iu',       0x0C3B: 'se-FI',       0x0420: 'ur',          
+    0x101A: 'hr-BA',    0x085D: 'iu-Latn',  0x043B: 'se',          0x0843: 'uz-Cyrl',     
+    0x0405: 'cs',       0x083C: 'ga',       0x083B: 'se-SE',       0x0443: 'uz',          
+    0x0406: 'da',       0x0434: 'xh',       0x203B: 'sms',         0x042A: 'vi',          
+    0x048C: 'prs',      0x0435: 'zu',       0x183B: 'sma-NO',      0x0452: 'cy',          
+    0x0465: 'dv',       0x0410: 'it',       0x1C3B: 'sms',         0x0488: 'wo',          
+    0x0813: 'nl-BE',    0x0810: 'it-CH',    0x044F: 'sa',          0x0485: 'sah',         
+    0x0413: 'nl',       0x0411: 'ja',       0x1C1A: 'sr-Cyrl-BA',  0x0478: 'ii',          
+    0x0C09: 'en-AU',    0x044B: 'kn',       0x0C1A: 'sr',          0x046A: 'yo',           
+    0x2809: 'en-BZ',    0x043F: 'kk',       0x181A: 'sr-Latn-BA',  
+    0x1009: 'en-CA',    0x0453: 'km',       0x081A: 'sr-Latn',     
+    0x2409: 'en-029',   0x0486: 'quc',      0x046C: 'nso',         
   }
 ];
 
-NameTable.process = function(stream) {
+NameTable.process = function(stream) {  
   var records = {};
   for (let record of this.records) {
     // find out what language this is for
     let language = LANGUAGES[record.platformID][record.languageID];
-
+    
     if (language == null && this.langTags != null && record.languageID >= 0x8000) {
       language = this.langTags[record.languageID - 0x8000].tag;
     }
-
+    
     if (language == null) {
       language = record.platformID + '-' + record.languageID;
     }
-
-    // check for reserved nameIDs
-    // if (20 <= record.nameID && record.nameID <= 255) {
-    //   throw new Error(`Reserved nameID ${record.nameID}`);
-    // }
-
+    
     // if the nameID is >= 256, it is a font feature record (AAT)
-    if (record.nameID >= 256) {
-      if (records.fontFeatures == null) { records.fontFeatures = {}; }
-      let feature = records.fontFeatures[language] != null ? records.fontFeatures[language] : (records.fontFeatures[language] = {});
-      feature[record.nameID] = record.string;
-    } else {
-      let key = NAMES[record.nameID] || record.nameID;
-      if (records[key] == null) { records[key] = {}; }
-      records[key][language] = record.string;
+    let key = record.nameID >= 256 ? 'fontFeatures' : (NAMES[record.nameID] || record.nameID);
+    if (records[key] == null) {
+      records[key] = {};
     }
+    
+    let obj = records[key];
+    if (record.nameID >= 256) {
+      obj = obj[record.nameID] || (obj[record.nameID] = {});
+    }
+    
+    obj[language] = record.string;
   }
-
+  
   this.records = records;
 };
 
 NameTable.preEncode = function() {
   if (Array.isArray(this.records)) return;
   this.version = 0;
-
+  
   let records = [];
   for (let key in this.records) {
     let val = this.records[key];
     if (key === 'fontFeatures') continue;
-
+    
     records.push({
       platformID: 3,
       encodingID: 1,
       languageID: 0x409,
       nameID: NAMES.indexOf(key),
-      length: Buffer.byteLength(val.English, 'utf16le'),
-      string: val.English
+      length: Buffer.byteLength(val.en, 'utf16le'),
+      string: val.en
     });
-
+      
     if (key === 'postscriptName') {
       records.push({
         platformID: 1,
         encodingID: 0,
         languageID: 0,
         nameID: NAMES.indexOf(key),
-        length: val.English.length,
-        string: val.English
+        length: val.en.length,
+        string: val.en
       });
     }
   }
-
+      
   this.records = records;
   this.count = records.length;
-  this.stringOffset = module.exports.size(this, null, false);
+  this.stringOffset = NameTable.size(this, null, false);
 };


### PR DESCRIPTION
Instead of textual language names. Records in the name table are now arranged in the reverse order to how they were before.

Before:

`font.name.English.description`

After:

`font.name.description.en`