### PR TITLE
Add support for getting string inputs from glyphs

### DIFF
--- a/src/CmapProcessor.js
+++ b/src/CmapProcessor.js
@@ -1,6 +1,7 @@
 import {binarySearch} from './utils';
 import {getEncoding} from './encodings';
 import {cache} from './decorators';
+import {range} from './utils';
 
 // iconv-lite is an optional dependency.
 try {
@@ -292,12 +293,4 @@ export default class CmapProcessor {
         throw new Error(`Unknown cmap format ${cmap.version}`);
     }
   }
-}
-
-function range(index, end) {
-  let range = [];
-  while (index < end) {
-    range.push(index++);
-  }
-  return range;
 }

--- a/src/CmapProcessor.js
+++ b/src/CmapProcessor.js
@@ -226,8 +226,45 @@ export default class CmapProcessor {
   codePointsForGlyph(gid) {
     let cmap = this.cmap;
     switch (cmap.version) {
-      case 0:
-        return cmap.codeMap.indexOf(gid);
+      case 0: {
+        let res = [];
+        for (let i = 0; i < 256; i++) {
+          if (cmap.codeMap.get(i) === gid) {
+            res.push(i);
+          }
+        }
+
+        return res;
+      }
+
+      case 4: {
+        let res = [];
+        for (let i = 0; i < cmap.segCount; i++) {
+          let end = cmap.endCode.get(i);
+          let start = cmap.startCode.get(i);
+          let rangeOffset = cmap.idRangeOffset.get(i);
+          let delta = cmap.idDelta.get(i);
+
+          for (var c = start; c <= end; c++) {
+            let g = 0;
+            if (rangeOffset === 0) {
+              g = c + delta;
+            } else {
+              let index = rangeOffset / 2 + (c - start) - (cmap.segCount - i);
+              g = cmap.glyphIndexArray.get(index) || 0;
+              if (g !== 0) {
+                g += delta;
+              }
+            }
+
+            if (g === gid) {
+              res.push(c);
+            }
+          }
+        }
+
+        return res;
+      }
 
       case 12: {
         let res = [];

--- a/src/CmapProcessor.js
+++ b/src/CmapProcessor.js
@@ -221,6 +221,40 @@ export default class CmapProcessor {
         throw new Error(`Unknown cmap format ${cmap.version}`);
     }
   }
+
+  @cache
+  codePointsForGlyph(gid) {
+    let cmap = this.cmap;
+    switch (cmap.version) {
+      case 0:
+        return cmap.codeMap.indexOf(gid);
+
+      case 12: {
+        let res = [];
+        for (let group of cmap.groups.toArray()) {
+          if (gid >= group.glyphID && gid <= group.glyphID + (group.endCharCode - group.startCharCode)) {
+            res.push(group.startCharCode + (gid - group.glyphID));
+          }
+        }
+
+        return res;
+      }
+
+      case 13: {
+        let res = [];
+        for (let group of cmap.groups.toArray()) {
+          if (gid === group.glyphID) {
+            res.push(...range(group.startCharCode, group.endCharCode + 1));
+          }
+        }
+
+        return res;
+      }
+
+      default:
+        throw new Error(`Unknown cmap format ${cmap.version}`);
+    }
+  }
 }
 
 function range(index, end) {

--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -296,7 +296,7 @@ export default class TTFFont {
     while (idx <= len) {
       let code = 0;
       let nextState = 0;
-      
+
       if (idx < len) {
         // Decode the next codepoint from UTF 16
         code = string.charCodeAt(idx++);
@@ -307,13 +307,13 @@ export default class TTFFont {
             code = ((code & 0x3ff) << 10) + (next & 0x3ff) + 0x10000;
           }
         }
-      
+
         // Compute the next state: 1 if the next codepoint is a variation selector, 0 otherwise.
         nextState = ((0xfe00 <= code && code <= 0xfe0f) || (0xe0100 <= code && code <= 0xe01ef)) ? 1 : 0;
       } else {
         idx++;
       }
-      
+
       if (state === 0 && nextState === 1) {
         // Variation selector following normal codepoint.
         glyphs.push(this.getGlyph(this._cmapProcessor.lookup(last, code), [last, code]));
@@ -321,7 +321,7 @@ export default class TTFFont {
         // Normal codepoint following normal codepoint.
         glyphs.push(this.glyphForCodePoint(last));
       }
-      
+
       last = code;
       state = nextState;
     }
@@ -343,8 +343,16 @@ export default class TTFFont {
    * @param {string} [language]
    * @return {GlyphRun}
    */
-  layout(string, userFeatures , script, language) {
+  layout(string, userFeatures, script, language) {
     return this._layoutEngine.layout(string, userFeatures, script, language);
+  }
+
+  /**
+   * Returns an array of strings that map to the given glyph id.
+   * @param {number} gid - glyph id
+   */
+  stringsForGlyph(gid) {
+    return this._layoutEngine.stringsForGlyph(gid);
   }
 
   /**

--- a/src/aat/AATLayoutEngine.js
+++ b/src/aat/AATLayoutEngine.js
@@ -4,6 +4,7 @@ import AATMorxProcessor from './AATMorxProcessor';
 
 export default class AATLayoutEngine {
   constructor(font) {
+    this.font = font;
     this.morxProcessor = new AATMorxProcessor(font);
   }
 
@@ -21,5 +22,29 @@ export default class AATLayoutEngine {
 
   getAvailableFeatures(script, language) {
     return AATFeatureMap.mapAATToOT(this.morxProcessor.getSupportedFeatures());
+  }
+
+  getStringsForGlyph(gid) {
+    let glyphStrings = this.morxProcessor.generateInputs(gid);
+    let result = [];
+
+    for (let glyphs of glyphStrings) {
+      this._addStrings(glyphs, 0, result, '');
+    }
+
+    return result;
+  }
+
+  _addStrings(glyphs, index, strings, string) {
+    let codePoints = this.font._cmapProcessor.codePointsForGlyph(glyphs[index].id);
+
+    for (let codePoint of codePoints) {
+      let s = string + String.fromCodePoint(codePoint);
+      if (index < glyphs.length - 1) {
+        this._addStrings(glyphs, index + 1, strings, s);
+      } else {
+        strings.push(s);
+      }
+    }
   }
 }

--- a/src/aat/AATLayoutEngine.js
+++ b/src/aat/AATLayoutEngine.js
@@ -24,7 +24,7 @@ export default class AATLayoutEngine {
     return AATFeatureMap.mapAATToOT(this.morxProcessor.getSupportedFeatures());
   }
 
-  getStringsForGlyph(gid) {
+  stringsForGlyph(gid) {
     let glyphStrings = this.morxProcessor.generateInputs(gid);
     let result = new Set;
 

--- a/src/aat/AATLayoutEngine.js
+++ b/src/aat/AATLayoutEngine.js
@@ -26,7 +26,7 @@ export default class AATLayoutEngine {
 
   getStringsForGlyph(gid) {
     let glyphStrings = this.morxProcessor.generateInputs(gid);
-    let result = [];
+    let result = new Set;
 
     for (let glyphs of glyphStrings) {
       this._addStrings(glyphs, 0, result, '');
@@ -43,7 +43,7 @@ export default class AATLayoutEngine {
       if (index < glyphs.length - 1) {
         this._addStrings(glyphs, index + 1, strings, s);
       } else {
-        strings.push(s);
+        strings.add(s);
       }
     }
   }

--- a/src/aat/AATLayoutEngine.js
+++ b/src/aat/AATLayoutEngine.js
@@ -36,7 +36,7 @@ export default class AATLayoutEngine {
   }
 
   _addStrings(glyphs, index, strings, string) {
-    let codePoints = this.font._cmapProcessor.codePointsForGlyph(glyphs[index].id);
+    let codePoints = this.font._cmapProcessor.codePointsForGlyph(glyphs[index]);
 
     for (let codePoint of codePoints) {
       let s = string + String.fromCodePoint(codePoint);

--- a/src/aat/AATLookupTable.js
+++ b/src/aat/AATLookupTable.js
@@ -1,3 +1,5 @@
+import {cache} from '../decorators';
+
 export default class AATLookupTable {
   constructor(table) {
     this.table = table;
@@ -70,4 +72,61 @@ export default class AATLookupTable {
         throw new Error(`Unknown lookup table format: ${this.table.version}`);
     }
   }
+
+  @cache
+  glyphsForValue(classValue) {
+    let res = [];
+
+    switch (this.table.version) {
+      case 2:
+      case 4: {
+        for (let segment of this.table.segments) {
+          if ((this.table.version === 2 && segment.value === classValue)) {
+            res.push(...range(segment.firstGlyph, segment.lastGlyph + 1));
+          } else {
+            for (let index = 0; index < segment.values.length; index++) {
+              if (segment.values[index] === classValue) {
+                res.push(segment.firstGlyph + index);
+              }
+            }
+          }
+        }
+
+        break;
+      }
+
+      case 6: {
+        for (let segment of this.table.segments) {
+          if (segment.value === classValue) {
+            res.push(segment.glyph);
+          }
+        }
+
+        break;
+      }
+
+      case 8: {
+        for (let i = 0; i < this.table.values.length; i++) {
+          if (this.table.values[i] === classValue) {
+            res.push(this.table.firstGlyph + i);
+          }
+        }
+
+        break;
+      }
+
+      default:
+        throw new Error(`Unknown lookup table format: ${this.table.version}`);
+    }
+
+    return res;
+  }
+}
+
+function range(index, end) {
+  let range = [];
+  while (index < end) {
+    range.push(index++);
+  }
+  return range;
 }

--- a/src/aat/AATLookupTable.js
+++ b/src/aat/AATLookupTable.js
@@ -1,4 +1,5 @@
 import {cache} from '../decorators';
+import {range} from '../utils';
 
 export default class AATLookupTable {
   constructor(table) {
@@ -78,7 +79,7 @@ export default class AATLookupTable {
     let res = [];
 
     switch (this.table.version) {
-      case 2:
+      case 2: // segment format
       case 4: {
         for (let segment of this.table.segments) {
           if ((this.table.version === 2 && segment.value === classValue)) {
@@ -95,7 +96,7 @@ export default class AATLookupTable {
         break;
       }
 
-      case 6: {
+      case 6: { // lookup single
         for (let segment of this.table.segments) {
           if (segment.value === classValue) {
             res.push(segment.glyph);
@@ -105,7 +106,7 @@ export default class AATLookupTable {
         break;
       }
 
-      case 8: {
+      case 8: { // lookup trimmed
         for (let i = 0; i < this.table.values.length; i++) {
           if (this.table.values[i] === classValue) {
             res.push(this.table.firstGlyph + i);
@@ -121,12 +122,4 @@ export default class AATLookupTable {
 
     return res;
   }
-}
-
-function range(index, end) {
-  let range = [];
-  while (index < end) {
-    range.push(index++);
-  }
-  return range;
 }

--- a/src/aat/AATMorxProcessor.js
+++ b/src/aat/AATMorxProcessor.js
@@ -332,11 +332,12 @@ export default class AATMorxProcessor {
         }
 
         if (count === 1) {
+          let result = input.map(g => g.id);
           let cache = this.inputCache[found];
           if (cache) {
-            cache.push(input.slice());
+            cache.push(result);
           } else {
-            this.inputCache[found] = [input.slice()];
+            this.inputCache[found] = [result];
           }
         }
       },

--- a/src/aat/AATMorxProcessor.js
+++ b/src/aat/AATMorxProcessor.js
@@ -322,19 +322,32 @@ export default class AATMorxProcessor {
 
     stateMachine.traverse({
       enter: (glyph, entry) => {
+        let glyphs = this.glyphs;
         stack.push({
-          glyphs: this.glyphs.slice(),
+          glyphs: glyphs.slice(),
           ligatureStack: this.ligatureStack.slice()
         });
 
+        // Add glyph to input and glyphs to process.
         let g = this.font.getGlyph(glyph);
         input.push(g);
-        this.glyphs.push(input[input.length - 1]);
+        glyphs.push(input[input.length - 1]);
 
-        process(this.glyphs[this.glyphs.length - 1], entry, this.glyphs.length - 1);
+        // Process ligature substitution
+        process(glyphs[glyphs.length - 1], entry, glyphs.length - 1);
 
-        let res = this.glyphs.filter(g => g.id !== 0xffff);
-        if (res.length === 1 && res[0].id === gid) {
+        // Add input to result if only one matching (non-deleted) glyph remains.
+        let match = false;
+        for (let i = 0; i < glyphs.length; i++) {
+          if (glyphs[i].id === gid) {
+            match = true;
+          } else if (glyphs[i].id !== 0xffff) {
+            match = false;
+            break;
+          }
+        }
+
+        if (match) {
           result.push(input.slice());
         }
       },

--- a/src/aat/AATMorxProcessor.js
+++ b/src/aat/AATMorxProcessor.js
@@ -1,5 +1,6 @@
 import AATStateMachine from './AATStateMachine';
 import AATLookupTable from './AATLookupTable';
+import {cache} from '../decorators';
 
 // indic replacement flags
 const MARK_FIRST = 0x8000;
@@ -90,11 +91,16 @@ export default class AATMorxProcessor {
     this.lastGlyph = null;
     this.markedIndex = null;
 
-    let stateMachine = new AATStateMachine(this.subtable.table.stateTable);
+    let stateMachine = this.getStateMachine(subtable);
     let process = this.getProcessor();
 
     let reverse = !!(this.subtable.coverage & REVERSE_DIRECTION);
     return stateMachine.process(this.glyphs, reverse, process);
+  }
+
+  @cache
+  getStateMachine(subtable) {
+    return new AATStateMachine(subtable.table.stateTable);
   }
 
   getProcessor() {

--- a/src/aat/AATStateMachine.js
+++ b/src/aat/AATStateMachine.js
@@ -57,4 +57,40 @@ export default class AATStateMachine {
 
     return glyphs;
   }
+
+  /**
+   * Performs a depth-first traversal of the glyph strings
+   * represented by the state machine.
+   */
+  traverse(opts, state = 0, visited = new Set) {
+    if (visited.has(state)) {
+      return;
+    }
+
+    visited.add(state);
+
+    let {nClasses, stateArray, entryTable} = this.stateTable;
+    let row = stateArray.getItem(state);
+
+    // Skip predefined classes
+    for (let classCode = 4; classCode < nClasses; classCode++) {
+      let entryIndex = row[classCode];
+      let entry = entryTable.getItem(entryIndex);
+
+      // Try all glyphs in the class
+      for (let glyph of this.lookupTable.glyphsForValue(classCode)) {
+        if (opts.enter) {
+          opts.enter(glyph, entry);
+        }
+
+        if (entry.newState !== 0) {
+          this.traverse(opts, entry.newState, visited);
+        }
+
+        if (opts.exit) {
+          opts.exit(glyph, entry);
+        }
+      }
+    }
+  }
 }

--- a/src/decorators.js
+++ b/src/decorators.js
@@ -1,13 +1,36 @@
 /**
- * This decorator caches the results of a getter such that
+ * This decorator caches the results of a getter or method such that
  * the results are lazily computed once, and then cached.
  * @private
  */
 export function cache(target, key, descriptor) {
-  var get = descriptor.get;
-  descriptor.get = function() {
-    let value = get.call(this);
-    Object.defineProperty(this, key, { value });
-    return value;
-  };
+  if (descriptor.get) {
+    let get = descriptor.get;
+    descriptor.get = function() {
+      let value = get.call(this);
+      Object.defineProperty(this, key, { value });
+      return value;
+    };
+  } else if (typeof descriptor.value === 'function') {
+    let fn = descriptor.value;
+
+    return {
+      get() {
+        let cache = new Map;
+        function memoized(...args) {
+          let key = args.length > 0 ? args[0] : 'value';
+          if (cache.has(key)) {
+            return cache.get(key);
+          }
+
+          let result = fn.apply(this, args);
+          cache.set(key, result);
+          return result;
+        };
+
+        Object.defineProperty(this, key, {value: memoized});
+        return memoized;
+      }
+    };
+  }
 }

--- a/src/glyph/TTFGlyph.js
+++ b/src/glyph/TTFGlyph.js
@@ -55,7 +55,8 @@ class Component {
     this.dx = dx;
     this.dy = dy;
     this.pos = 0;
-    this.scale = this.xScale = this.yScale = this.scale01 = this.scale10 = null;
+    this.scaleX = this.scaleY = 1;
+    this.scale01 = this.scale10 = 0;
   }
 }
 
@@ -200,8 +201,6 @@ export default class TTFGlyph extends Glyph {
 
       var component = new Component(glyphID, dx, dy);
       component.pos = gPos;
-      component.scaleX = component.scaleY = 1;
-      component.scale01 = component.scale10 = 0;
 
       if (flags & WE_HAVE_A_SCALE) {
         // fixed number with 14 bits of fraction
@@ -276,7 +275,7 @@ export default class TTFGlyph extends Glyph {
         }
       }
     } else {
-      var { points } = glyph;
+      var points = glyph.points || [];
     }
 
     // Recompute and cache metrics if we performed variation processing

--- a/src/layout/LayoutEngine.js
+++ b/src/layout/LayoutEngine.js
@@ -137,7 +137,7 @@ export default class LayoutEngine {
       result.add(String.fromCodePoint(codePoint));
     }
 
-    if (this.engine) {
+    if (this.engine && this.engine.stringsForGlyph) {
       for (let string of this.engine.stringsForGlyph(gid)) {
         result.add(string);
       }

--- a/src/layout/LayoutEngine.js
+++ b/src/layout/LayoutEngine.js
@@ -129,7 +129,7 @@ export default class LayoutEngine {
     return features;
   }
 
-  getStringsForGlyph(gid) {
+  stringsForGlyph(gid) {
     let result = new Set;
 
     let codePoints = this.font._cmapProcessor.codePointsForGlyph(gid);
@@ -138,7 +138,7 @@ export default class LayoutEngine {
     }
 
     if (this.engine) {
-      for (let string of this.engine.getStringsForGlyph(gid)) {
+      for (let string of this.engine.stringsForGlyph(gid)) {
         result.add(string);
       }
     }

--- a/src/layout/LayoutEngine.js
+++ b/src/layout/LayoutEngine.js
@@ -128,4 +128,19 @@ export default class LayoutEngine {
 
     return features;
   }
+
+  getStringsForGlyph(gid) {
+    let result = [];
+
+    let codePoints = this.font._cmapProcessor.codePointsForGlyph(gid);
+    for (let codePoint of codePoints) {
+      result.push(String.fromCodePoint(codePoint));
+    }
+
+    if (this.engine) {
+      result.push(...this.engine.getStringsForGlyph(gid));
+    }
+
+    return result;
+  }
 }

--- a/src/layout/LayoutEngine.js
+++ b/src/layout/LayoutEngine.js
@@ -130,17 +130,19 @@ export default class LayoutEngine {
   }
 
   getStringsForGlyph(gid) {
-    let result = [];
+    let result = new Set;
 
     let codePoints = this.font._cmapProcessor.codePointsForGlyph(gid);
     for (let codePoint of codePoints) {
-      result.push(String.fromCodePoint(codePoint));
+      result.add(String.fromCodePoint(codePoint));
     }
 
     if (this.engine) {
-      result.push(...this.engine.getStringsForGlyph(gid));
+      for (let string of this.engine.getStringsForGlyph(gid)) {
+        result.add(string);
+      }
     }
 
-    return result;
+    return Array.from(result);
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,6 +13,14 @@ export function binarySearch(arr, cmp) {
       return mid;
     }
   }
-  
+
   return -1;
+}
+
+export function range(index, end) {
+  let range = [];
+  while (index < end) {
+    range.push(index++);
+  }
+  return range;
 }

--- a/test/glyph_mapping.js
+++ b/test/glyph_mapping.js
@@ -28,13 +28,13 @@ describe('character to glyph mapping', function() {
       assert.deepEqual(glyphs.map(g => g.id), [75, 72, 79, 79, 82]);
       return assert.deepEqual(glyphs.map(g => g.codePoints), [[104], [101], [108], [108], [111]]);
     });
-    
+
     it('should support unicode variation selectors', function() {
       let font = fontkit.openSync(__dirname + '/data/fonttest/TestCMAP14.otf');
       let glyphs = font.glyphsForString('\u{82a6}\u{82a6}\u{E0100}\u{82a6}\u{E0101}');
       assert.deepEqual(glyphs.map(g => g.id), [1, 1, 2]);
     });
-    
+
     it('should support legacy encodings when no unicode cmap is found', function() {
       let font = fontkit.openSync(__dirname + '/data/fonttest/TestCMAPMacTurkish.ttf');
       let glyphs = font.glyphsForString("“ABÇĞIİÖŞÜ”");
@@ -101,6 +101,20 @@ describe('character to glyph mapping', function() {
         [ 6041 ], [ 6018 ], [ 6098, 6040 ], [ 6070 ], [ 6035 ], [ 6036 ], [ 6025 ],
         [ 6098, 6048 ], [ 6070 ]
       ]);
+    });
+  });
+
+  describe('glyph id to strings', function () {
+    it('should return strings from cmap that map to a given glyph', function () {
+      let font = fontkit.openSync(__dirname + '/data/OpenSans/OpenSans-Regular.ttf');
+      let strings = font.stringsForGlyph(68);
+      assert.deepEqual(strings, ['a']);
+    });
+
+    it('should return strings from AAT morx table that map to the given glyph', function () {
+      let font = fontkit.openSync(__dirname + '/data/Play/Play-Regular.ttf');
+      let strings = font.stringsForGlyph(767);
+      assert.deepEqual(strings, ['ffi']);
     });
   });
 });


### PR DESCRIPTION
Basically solves #56. Does the inverse of `font.layout`: it maps glyphs back to their input strings. This is complicated by ligatures and other substitutions. Currently, this supports AAT by viewing the state table as a graph, and doing a traversal over it to find inputs that produce a given glyph. It runs the state machine actions as it generates inputs. Obviously, things like loops in the state machine have to be ignored or an infinite number of strings would be produced.

Some AAT state tables (like [the one in Apple Color Emoji](https://cldup.com/AsISJp9XXO.png)) are really huge, so this is kinda slow. I added a bunch of caching for the lookup tables to speed it up a bit, and skip subtables that don't have the glyph id in their ligature lists. This type of operation should be much more rare than going from strings to glyphs however, so I think we're ok if it's not super fast.

To support GSUB, we will need to do something like [hb-input](https://github.com/googlei18n/nototools/blob/master/nototools/hb_input.py). We should also probably support non-contextual substitutions for AAT, which should be easy.