### PR TITLE
adds tests for font.layout 'fi'

### DIFF
--- a/src/layout/LayoutEngine.js
+++ b/src/layout/LayoutEngine.js
@@ -31,6 +31,7 @@ export default class LayoutEngine {
       features = [];
     }
 
+    console.log({ string, script, scriptNull: script == null });
     // Map string to glyphs if needed
     if (typeof string === 'string') {
       // Attempt to detect the script from the string if not provided.
@@ -53,6 +54,8 @@ export default class LayoutEngine {
       var glyphs = string;
     }
 
+    console.log({ glyphs })
+
     // Return early if there are no glyphs
     if (glyphs.length === 0) {
       return new GlyphRun(glyphs, []);
@@ -65,6 +68,9 @@ export default class LayoutEngine {
 
     // Substitute and position the glyphs
     glyphs = this.substitute(glyphs, features, script, language);
+
+    console.log('substitute', { glyphs })
+
     let positions = this.position(glyphs, features, script, language);
 
     // Let the layout engine clean up any state it might have

--- a/test/glyph_mapping.js
+++ b/test/glyph_mapping.js
@@ -42,6 +42,19 @@ describe('character to glyph mapping', function() {
     });
   });
 
+  describe.only('layout bug', function() {
+    let font = fontkit.openSync(__dirname + '/data/OpenSans/OpenSans-Regular.ttf');
+    it('should return the right glyfs for "f i"', function() {
+      let {glyphs} = font.layout('f i');
+      return assert.deepEqual(glyphs.map(g => g.id), [ 73, 3, 76 ]);
+    });
+
+    it('should return the right glyfs for "fi"', function() {
+      let {glyphs} = font.layout('fi');
+      return assert.deepEqual(glyphs.map(g => g.id), [ 73, 76 ]);
+    });
+  });
+
   describe('opentype features', function() {
     let font = fontkit.openSync(__dirname + '/data/SourceSansPro/SourceSansPro-Regular.otf');
 


### PR DESCRIPTION
Should the two tests pass? Currently only the first one does.
Seems to be an issue with the OTLayoutEngine.substitute method, but that's as deep as I got.
