### PR TITLE
Fix fonts without postscript name fails

### DIFF
--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -90,6 +90,9 @@ export default class TTFFont {
    * @type {string}
    */
   get postscriptName() {
+    if (this.name === undefined || this.name.records.postscriptName === undefined) {
+        return "";
+    }
     let name = this.name.records.postscriptName;
     let lang = Object.keys(name)[0];
     return name[lang];


### PR DESCRIPTION
Fixes issue [#73](https://github.com/devongovett/fontkit/issues/73)  