### PR TITLE
[WIP] Support subsetting CFF2 fonts for use in PDFs

### DIFF
--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -408,7 +408,7 @@ export default class TTFFont {
    * @return {Subset}
    */
   createSubset() {
-    if (this.directory.tables['CFF ']) {
+    if (this.directory.tables['CFF '] || this.directory.tables.CFF2) {
       return new CFFSubset(this);
     }
 

--- a/src/cff/CFFFont.js
+++ b/src/cff/CFFFont.js
@@ -109,6 +109,10 @@ class CFFFont {
 
   fdForGlyph(gid) {
     if (!this.topDict.FDSelect) {
+      if (this.topDict.FDArray) {
+        return 0;
+      }
+
       return null;
     }
 
@@ -139,8 +143,8 @@ class CFFFont {
   }
 
   privateDictForGlyph(gid) {
-    if (this.topDict.FDSelect) {
-      let fd = this.fdForGlyph(gid);
+    let fd = this.fdForGlyph(gid);
+    if (fd != null) {
       if (this.topDict.FDArray[fd]) {
         return this.topDict.FDArray[fd].Private;
       }
@@ -148,11 +152,7 @@ class CFFFont {
       return null;
     }
 
-    if (this.version < 2) {
-      return this.topDict.Private;
-    }
-
-    return this.topDict.FDArray[0].Private;
+    return this.topDict.Private;
   }
 }
 

--- a/src/cff/CFFTop.js
+++ b/src/cff/CFFTop.js
@@ -214,8 +214,9 @@ let CFF2TopDict = new CFFDict([
   [25,        'maxstack',             'number',                               193]
 ]);
 
-let CFFTop = new r.VersionedStruct(r.fixed16, {
+let CFFTop = new r.VersionedStruct(r.uint8, {
   1: {
+    minorVersion:       r.uint8,
     hdrSize:            r.uint8,
     offSize:            r.uint8,
     nameIndex:          new CFFIndex(new r.String('length')),
@@ -225,6 +226,7 @@ let CFFTop = new r.VersionedStruct(r.fixed16, {
   },
 
   2: {
+    minorVersion:       r.uint8,
     hdrSize:            r.uint8,
     length:             r.uint16,
     topDict:            CFF2TopDict,

--- a/src/glyph/CFFGlyph.js
+++ b/src/glyph/CFFGlyph.js
@@ -1,5 +1,6 @@
 import Glyph from './Glyph';
 import Path from './Path';
+import CFFOperand from '../cff/CFFOperand';
 
 /**
  * Represents an OpenType PostScript glyph, in the Compact Font Format.
@@ -574,16 +575,8 @@ export default class CFFGlyph extends Glyph {
               throw new Error(`Unknown op: ${op}`);
           }
 
-        } else if (op < 247) {
-          stack.push(op - 139);
-        } else if (op < 251) {
-          var b1 = stream.readUInt8();
-          stack.push((op - 247) * 256 + b1 + 108);
-        } else if (op < 255) {
-          var b1 = stream.readUInt8();
-          stack.push(-(op - 251) * 256 - b1 - 108);
         } else {
-          stack.push(stream.readInt32BE() / 65536);
+          stack.push(CFFOperand.decode(stream, op));
         }
       }
     };


### PR DESCRIPTION
Basically we have to convert CFF2 to CFF1 to enable PDF viewers to work with CFF2 fonts. This means generating some info from other places in the font since it no longer exists in CFF2 (e.g. font names, etc.). Also, we have to generate a static instance of any variations applied by re-encoding charstrings after applying the `blend` operator.

Still to figure out: how to remove overlapping subpaths from glyph outlines since CFF2 allows them, but CFF1 does not. CFF2 switched from the even-odd to the nonzero winding rule. This will require some additional processing on the glyph paths...