### PR TITLE
Allow user to override shaper features

### DIFF
--- a/src/TTFFont.js
+++ b/src/TTFFont.js
@@ -365,6 +365,10 @@ export default class TTFFont {
     return this._layoutEngine.getAvailableFeatures();
   }
 
+  getAvailableFeatures(script, language) {
+    return this._layoutEngine.getAvailableFeatures(script, language);
+  }
+
   _getBaseGlyph(glyph, characters = []) {
     if (!this._glyphs[glyph]) {
       if (this.directory.tables.glyf) {

--- a/src/aat/AATFeatureMap.js
+++ b/src/aat/AATFeatureMap.js
@@ -478,14 +478,14 @@ for (let ot in OTMapping) {
 // in the form of {featureType:{featureSetting:true}}
 export function mapOTToAAT(features) {
   let res = {};
-  for (let k = 0; k < features.length; k++) {
+  for (let k in features) {
     let r;
-    if (r = OTMapping[features[k]]) {
+    if (r = OTMapping[k]) {
       if (res[r[0]] == null) {
         res[r[0]] = {};
       }
 
-      res[r[0]][r[1]] = true;
+      res[r[0]][r[1]] = features[k];
     }
   }
 

--- a/src/aat/AATLayoutEngine.js
+++ b/src/aat/AATLayoutEngine.js
@@ -9,16 +9,14 @@ export default class AATLayoutEngine {
     this.fallbackPosition = false;
   }
 
-  substitute(glyphs, features, script, language) {
+  substitute(glyphRun) {
     // AAT expects the glyphs to be in visual order prior to morx processing,
     // so reverse the glyphs if the script is right-to-left.
-    let isRTL = Script.direction(script) === 'rtl';
-    if (isRTL) {
+    if (glyphRun.direction === 'rtl') {
       glyphs.reverse();
     }
 
-    this.morxProcessor.process(glyphs, AATFeatureMap.mapOTToAAT(features));
-    return glyphs;
+    this.morxProcessor.process(glyphRun.glyphs, AATFeatureMap.mapOTToAAT(glyphRun.features));
   }
 
   getAvailableFeatures(script, language) {

--- a/src/layout/GlyphRun.js
+++ b/src/layout/GlyphRun.js
@@ -1,11 +1,12 @@
 import BBox from '../glyph/BBox';
+import * as Script from '../layout/Script';
 
 /**
  * Represents a run of Glyph and GlyphPosition objects.
  * Returned by the font layout method.
  */
 export default class GlyphRun {
-  constructor(glyphs, positions) {
+  constructor(glyphs, features, script, language) {
     /**
      * An array of Glyph objects in the run
      * @type {Glyph[]}
@@ -16,7 +17,42 @@ export default class GlyphRun {
      * An array of GlyphPosition objects for each glyph in the run
      * @type {GlyphPosition[]}
      */
-    this.positions = positions;
+    this.positions = null;
+
+    /**
+     * The script that was used for shaping. This was either passed in or detected automatically.
+     * @type {string}
+     */
+    this.script = script;
+
+    /**
+     * The language used for shaping, as passed in. If `null`, the default language for the
+     * script was used.
+     * @type {string}
+     */
+    this.language = language || null;
+
+    /**
+     * The directionality of the script (either ltr or rtl).
+     * @type {string}
+     */
+    this.direction = Script.direction(script);
+
+    /**
+     * The features applied during shaping. This is a combination of user
+     * specified features and features chosen by the shaper.
+     * @type {object}
+     */
+    this.features = {};
+
+    // Convert features to an object
+    if (Array.isArray(features)) {
+      for (let tag of features) {
+        this.features[tag] = true;
+      }
+    } else if (typeof features === 'object') {
+      this.features = features;
+    }
   }
 
   /**

--- a/src/layout/GlyphRun.js
+++ b/src/layout/GlyphRun.js
@@ -20,26 +20,26 @@ export default class GlyphRun {
     this.positions = null;
 
     /**
-     * The script that was used for shaping. This was either passed in or detected automatically.
+     * The script that was requested for shaping. This was either passed in or detected automatically.
      * @type {string}
      */
     this.script = script;
 
     /**
-     * The language used for shaping, as passed in. If `null`, the default language for the
+     * The language requested for shaping, as passed in. If `null`, the default language for the
      * script was used.
      * @type {string}
      */
     this.language = language || null;
 
     /**
-     * The directionality of the script (either ltr or rtl).
+     * The directionality of the requested script (either ltr or rtl).
      * @type {string}
      */
     this.direction = Script.direction(script);
 
     /**
-     * The features applied during shaping. This is a combination of user
+     * The features requested during shaping. This is a combination of user
      * specified features and features chosen by the shaper.
      * @type {object}
      */

--- a/src/layout/LayoutEngine.js
+++ b/src/layout/LayoutEngine.js
@@ -23,7 +23,7 @@ export default class LayoutEngine {
     }
   }
 
-  layout(string, features = [], script, language) {
+  layout(string, features, script, language) {
     // Make the features parameter optional
     if (typeof features === 'string') {
       script = features;
@@ -53,45 +53,45 @@ export default class LayoutEngine {
       var glyphs = string;
     }
 
+    let glyphRun = new GlyphRun(glyphs, features, script, language);
+
     // Return early if there are no glyphs
     if (glyphs.length === 0) {
-      return new GlyphRun(glyphs, []);
+      return glyphRun;
     }
 
     // Setup the advanced layout engine
     if (this.engine && this.engine.setup) {
-      this.engine.setup(glyphs, features, script, language);
+      this.engine.setup(glyphRun);
     }
 
     // Substitute and position the glyphs
-    glyphs = this.substitute(glyphs, features, script, language);
-    let positions = this.position(glyphs, features, script, language);
+    this.substitute(glyphRun);
+    this.position(glyphRun);
 
     // Let the layout engine clean up any state it might have
     if (this.engine && this.engine.cleanup) {
       this.engine.cleanup();
     }
 
-    return new GlyphRun(glyphs, positions);
+    return glyphRun;
   }
 
-  substitute(glyphs, features, script, language) {
+  substitute(glyphRun) {
     // Call the advanced layout engine to make substitutions
     if (this.engine && this.engine.substitute) {
-      glyphs = this.engine.substitute(glyphs, features, script, language);
+      this.engine.substitute(glyphRun);
     }
-
-    return glyphs;
   }
 
-  position(glyphs, features, script, language) {
+  position(glyphRun) {
     // Get initial glyph positions
-    let positions = glyphs.map(glyph => new GlyphPosition(glyph.advanceWidth));
+    glyphRun.positions = glyphRun.glyphs.map(glyph => new GlyphPosition(glyph.advanceWidth));
     let positioned = null;
 
     // Call the advanced layout engine. Returns the features applied.
     if (this.engine && this.engine.position) {
-      positioned = this.engine.position(glyphs, positions, features, script, language);
+      positioned = this.engine.position(glyphRun);
     }
 
     // if there is no GPOS table, use unicode properties to position marks.
@@ -100,19 +100,18 @@ export default class LayoutEngine {
         this.unicodeLayoutEngine = new UnicodeLayoutEngine(this.font);
       }
 
-      this.unicodeLayoutEngine.positionGlyphs(glyphs, positions);
+      this.unicodeLayoutEngine.positionGlyphs(glyphRun.glyphs, glyphRun.positions);
     }
 
     // if kerning is not supported by GPOS, do kerning with the TrueType/AAT kern table
-    if ((!positioned || !positioned.kern) && this.font.kern) {
+    if ((!positioned || !positioned.kern) && glyphRun.features.kern !== false && this.font.kern) {
       if (!this.kernProcessor) {
         this.kernProcessor = new KernProcessor(this.font);
       }
 
-      this.kernProcessor.process(glyphs, positions);
+      this.kernProcessor.process(glyphRun.glyphs, glyphRun.positions);
+      glyphRun.features.kern = true;
     }
-
-    return positions;
   }
 
   getAvailableFeatures(script, language) {

--- a/src/opentype/OTProcessor.js
+++ b/src/opentype/OTProcessor.js
@@ -56,10 +56,6 @@ export default class OTProcessor {
     let entry;
     if (!this.script || script !== this.scriptTag) {
       entry = this.findScript(script);
-      if (script) {
-        entry = this.findScript(script);
-      }
-
       if (!entry) {
         entry = this.findScript(DEFAULT_SCRIPTS);
       }
@@ -72,22 +68,27 @@ export default class OTProcessor {
       this.script = entry.script;
       this.direction = Script.direction(script);
       this.language = null;
+      this.languageTag = null;
       changed = true;
     }
 
-    if (!language && language !== this.langugeTag) {
+    if (!language || language !== this.languageTag) {
+      this.language = null;
+
       for (let lang of this.script.langSysRecords) {
         if (lang.tag === language) {
           this.language = lang.langSys;
-          this.langugeTag = lang.tag;
-          changed = true;
+          this.languageTag = lang.tag;
           break;
         }
       }
-    }
 
-    if (!this.language) {
-      this.language = this.script.defaultLangSys;
+      if (!this.language) {
+        this.language = this.script.defaultLangSys;
+        this.languageTag = null;
+      }
+
+      changed = true;
     }
 
     // Build a feature lookup table

--- a/src/opentype/ShapingPlan.js
+++ b/src/opentype/ShapingPlan.js
@@ -31,10 +31,10 @@ export default class ShapingPlan {
       if (this.allFeatures[feature] == null) {
         stage.push(feature);
         this.allFeatures[feature] = stageIndex;
-      }
 
-      if (global) {
-        this.globalFeatures[feature] = true;
+        if (global) {
+          this.globalFeatures[feature] = true;
+        }
       }
     }
   }

--- a/src/opentype/shapers/DefaultShaper.js
+++ b/src/opentype/shapers/DefaultShaper.js
@@ -37,7 +37,8 @@ export default class DefaultShaper {
   }
 
   static planPostprocessing(plan, userFeatures) {
-    plan.add([...COMMON_FEATURES, ...HORIZONTAL_FEATURES, ...userFeatures]);
+    plan.add([...COMMON_FEATURES, ...HORIZONTAL_FEATURES]);
+    plan.setFeatureOverrides(userFeatures);
   }
 
   static assignFeatures(plan, glyphs) {

--- a/test/glyph_mapping.js
+++ b/test/glyph_mapping.js
@@ -55,10 +55,10 @@ describe('character to glyph mapping', function() {
     );
 
     it('should apply opentype GSUB features', function() {
-      let {glyphs} = font.layout('ffi 1/2', ['liga', 'dlig', 'frac']);
-      assert.equal(glyphs.length, 6);
-      assert.deepEqual(glyphs.map(g => g.id), [ 514, 36, 1, 1617, 1726, 1604 ]);
-      return assert.deepEqual(glyphs.map(g => g.codePoints), [[102, 102], [105], [32], [49], [47], [50]]);
+      let {glyphs} = font.layout('ffi', ['dlig']);
+      assert.equal(glyphs.length, 2);
+      assert.deepEqual(glyphs.map(g => g.id), [ 514, 36 ]);
+      return assert.deepEqual(glyphs.map(g => g.codePoints), [[102, 102], [105]]);
     });
 
     it('should enable fractions when using fraction slash', function() {


### PR DESCRIPTION
Along with support for passing an array of feature tags to `font.layout`, you can now pass an object with values explicitly set to false to disable those features if they were automatically applied by a shaper. This is to allow e.g. a UI to let the user control some feature behavior manually. 

Also passes back the script, language, and features that were selected as part of the resulting `GlyphRun`.