### PR TITLE
Make automatic fraction code a bit more robust

### DIFF
--- a/src/opentype/shapers/DefaultShaper.js
+++ b/src/opentype/shapers/DefaultShaper.js
@@ -43,17 +43,16 @@ export default class DefaultShaper {
 
   static assignFeatures(plan, glyphs) {
     // Enable contextual fractions
-    let i = 0;
-    while (i < glyphs.length) {
+    for (let i = 0; i < glyphs.length; i++) {
       let glyph = glyphs[i];
       if (glyph.codePoints[0] === 0x2044) { // fraction slash
-        let start = i - 1;
+        let start = i;
         let end = i + 1;
 
         // Apply numerator
-        while (start >= 0 && unicode.isDigit(glyphs[start].codePoints[0])) {
-          glyphs[start].features.numr = true;
-          glyphs[start].features.frac = true;
+        while (start > 0 && unicode.isDigit(glyphs[start - 1].codePoints[0])) {
+          glyphs[start - 1].features.numr = true;
+          glyphs[start - 1].features.frac = true;
           start--;
         }
 
@@ -67,9 +66,6 @@ export default class DefaultShaper {
         // Apply fraction slash
         glyph.features.frac = true;
         i = end - 1;
-
-      } else {
-        i++;
       }
     }
   }

--- a/test/glyph_mapping.js
+++ b/test/glyph_mapping.js
@@ -65,6 +65,11 @@ describe('character to glyph mapping', function() {
       let {glyphs} = font.layout('123 1⁄16 123');
       return assert.deepEqual(glyphs.map(g => g.id), [ 1088, 1089, 1090, 1, 1617, 1724, 1603, 1608, 1, 1088, 1089, 1090 ]);
     });
+
+    it('should not break if can’t enable fractions when using fraction slash', function() {
+      let {glyphs} = font.layout('a⁄b ⁄ 1⁄ ⁄2');
+      return assert.deepEqual(glyphs.map(g => g.id), [ 28, 1724, 29, 1, 1724, 1, 1617, 1724, 1, 1724, 1604 ]);
+    });
   });
 
   describe('AAT features', function() {


### PR DESCRIPTION
Don’t enter into infinite loop when no digits are found for numerator or denominator.

Fixes https://github.com/devongovett/fontkit/issues/123.