### PR TITLE
Fix bbox for GlyphRun with blank glyphs

### DIFF
--- a/src/glyph/BBox.js
+++ b/src/glyph/BBox.js
@@ -45,20 +45,24 @@ export default class BBox {
   }
 
   addPoint(x, y) {
-    if (x < this.minX) {
-      this.minX = x;
+    if (Math.abs(x) != Infinity) {
+      if (x < this.minX) {
+        this.minX = x;
+      }
+
+      if (x > this.maxX) {
+        this.maxX = x;
+      }
     }
 
-    if (y < this.minY) {
-      this.minY = y;
-    }
+    if (Math.abs(y) != Infinity) {
+      if (y < this.minY) {
+        this.minY = y;
+      }
 
-    if (x > this.maxX) {
-      this.maxX = x;
-    }
-
-    if (y > this.maxY) {
-      this.maxY = y;
+      if (y > this.maxY) {
+        this.maxY = y;
+      }
     }
   }
 

--- a/test/glyphs.js
+++ b/test/glyphs.js
@@ -47,6 +47,11 @@ describe('glyphs', function() {
       return assert.deepEqual(glyph.bbox, new BBox(201, 0, 1368, 1462));
     });
 
+    it('should get correct bbox for runs containing blanks', function () {
+      let r = font.layout('abc ef');
+      return assert.deepEqual(r.bbox, new BBox(94, -20, 5832, 1567));
+    });
+
     it('should get the advance width', function() {
       let glyph = font.getGlyph(39);
       return assert.equal(glyph.advanceWidth | 0, 1493);


### PR DESCRIPTION
A blank glyph will have an empty bbox (everything initialized to Infinity) and adding its bbox to the GlyphRun bbox will result in the later being all Infinity as well.

 Fix this by checking for Infinity in BBox.addPoint(). Not sure if this is the best fix, alternatively we can add a BBox.isEmpty() or something similar and skip such boxes when calculating GlyphRun bbox.

Fixes https://github.com/devongovett/fontkit/issues/103