### PR TITLE
Enable CI on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ node_js:
   - stable
   - "6"
   - "4"
+matrix:
+  include:
+    - os: osx
+      node_js: stable


### PR DESCRIPTION
Building only with stable nodejs to cut the CI run time, I think testing other versions only on Linux is enough.