### PR TITLE
Fix subsetting CID fonts with no subrs

### DIFF
--- a/src/subset/CFFSubset.js
+++ b/src/subset/CFFSubset.js
@@ -100,7 +100,9 @@ export default class CFFSubset extends Subset {
     }
 
     let privateDict = Object.assign({}, this.cff.topDict.Private);
-    privateDict.Subrs = this.subsetSubrs(this.cff.topDict.Private.Subrs, used_subrs);
+    if (this.cff.topDict.Private && this.cff.topDict.Private.Subrs) {
+      privateDict.Subrs = this.subsetSubrs(this.cff.topDict.Private.Subrs, used_subrs);
+    }
 
     topDict.FDArray = [{ Private: privateDict }];
     return topDict.FDSelect = {


### PR DESCRIPTION
Attempting to subset a CID-keyed CFF font with no subrs triggers a `TypeError` in CFFSubset.js because `subsetSubrs()` attempts to check the `.length` of null. This PR addresses that by not attempting to subset subrs at all if they do not exist in the font.

Fixes issue #42 (well, kinda but not really, the original issue that concerns is long gone but I found a related problem that should have been in a new issue). I didn't come up with this fix, credits go to @jahewson for pointing it out.