### PR TITLE
BUG FIX: Glyph isMark attribute is set to true when codepoints array is empty

### DIFF
--- a/src/glyph/Glyph.js
+++ b/src/glyph/Glyph.js
@@ -29,7 +29,7 @@ export default class Glyph {
     this._font = font;
 
     // TODO: get this info from GDEF if available
-    this.isMark = this.codePoints.every(unicode.isMark);
+    this.isMark = this.codePoints.length > 0 && this.codePoints.every(unicode.isMark);
     this.isLigature = this.codePoints.length > 1;
   }
 

--- a/src/opentype/GlyphInfo.js
+++ b/src/opentype/GlyphInfo.js
@@ -44,7 +44,7 @@ export default class GlyphInfo {
       this.isMark = classID === 3;
       this.markAttachmentType = GDEF.markAttachClassDef ? OTProcessor.prototype.getClassID(id, GDEF.markAttachClassDef) : 0;
     } else {
-      this.isMark = this.codePoints.every(unicode.isMark);
+      this.isMark = this.codePoints.length > 0 && this.codePoints.every(unicode.isMark);
       this.isBase = !this.isMark;
       this.isLigature = this.codePoints.length > 1;
       this.markAttachmentType = 0;


### PR DESCRIPTION
If codePoints array in glyph constructor is empty then isMark attribute is true, which is wrong. CodePoints array may be empty if getGlyph method is called directly.