### PR TITLE
Keep stringIndex for default ignorables glyphs

### DIFF
--- a/src/layout/LayoutEngine.js
+++ b/src/layout/LayoutEngine.js
@@ -160,10 +160,10 @@ export default class LayoutEngine {
   }
 
   hideDefaultIgnorables(glyphs, positions) {
-    let space = this.font.glyphForCodePoint(0x20);
+    const space = this.font.glyphForCodePoint(0x20);
     for (let i = 0; i < glyphs.length; i++) {
       if (this.isDefaultIgnorable(glyphs[i].codePoints[0])) {
-        glyphs[i] = space;
+        glyphs[i].id = space.id;
         positions[i].xAdvance = 0;
         positions[i].yAdvance = 0;
       }


### PR DESCRIPTION
Instead of fully replacing the glyph with the new space glyph instance, we just edit the `id` reference (which will produce the same glyph after all when [`getGlyph` is called](https://github.com/devongovett/fontkit/compare/string-index...diegomura:keep-string-index?expand=1#diff-269e3f2bf3adeb025b323ae430859705R68)) **but** we keep the `stringIndex` glyph attribute, now needed [in here] (https://github.com/devongovett/fontkit/compare/string-index...diegomura:keep-string-index?expand=1#diff-269e3f2bf3adeb025b323ae430859705R67) to return it with the GlyphRun.

This is supposed to be merged to the `string-index` branch, which is still experimental @devongovett 